### PR TITLE
Fix style leaks

### DIFF
--- a/src/visualizations/heatmap/HeatmapSettings.ts
+++ b/src/visualizations/heatmap/HeatmapSettings.ts
@@ -140,22 +140,22 @@ export default class HeatmapSettings extends Settings {
     ) => string = (value: HeatmapValue, row: HeatmapFeature, column: HeatmapFeature) => {
         return `
             <style>
-                .tooltip {
+                .unipept-tooltip {
                     padding: 10px;
                     border-radius: 5px; 
                     background: rgba(0, 0, 0, 0.8); 
                     color: #fff;
                 }
                 
-                .tooltip div,a {
+                .unipept-tooltip div, .unipept-tooltip a {
                     font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 }
                 
-                .tooltip div {
+                .unipept-tooltip div {
                     font-weight: bold;
                 }
             </style>
-            <div class="tooltip">
+            <div class="unipept-tooltip">
                 <div>
                     ${this.getTooltipTitle(value, row, column)}
                 </div>

--- a/src/visualizations/sunburst/SunburstSettings.ts
+++ b/src/visualizations/sunburst/SunburstSettings.ts
@@ -83,7 +83,7 @@ export default class SunburstSettings extends Settings {
                     color: #fff;
                 }
                 
-                .unipept-tooltip div,a {
+                .unipept-tooltip div, .unipept-tooltip a {
                     font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 }
                 

--- a/src/visualizations/treemap/TreemapSettings.ts
+++ b/src/visualizations/treemap/TreemapSettings.ts
@@ -66,7 +66,7 @@ export default class TreemapSettings extends Settings {
                     color: #fff;
                 }
                 
-                .unipept-tooltip div,a {
+                .unipept-tooltip div, .unipept-tooltip a {
                     font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 }
                 

--- a/src/visualizations/treeview/TreeviewSettings.ts
+++ b/src/visualizations/treeview/TreeviewSettings.ts
@@ -132,7 +132,7 @@ export default class TreeviewSettings extends Settings {
                     color: #fff;
                 }
                 
-                .unipept-tooltip div,a {
+                .unipept-tooltip div, .unipept-tooltip a {
                     font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 }
                 


### PR DESCRIPTION
This PR fixes the style leaks by 1) using a less generic name for the tooltip class and 2) fixing a mistake in the css-selector for tooltips that accidentally matched all `a`-tags.