### PR TITLE
Make the lint job actually check something

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,39 +1,47 @@
-import { defineConfig, globalIgnores } from 'eslint/config';
+import js from '@eslint/js';
 import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 
-export default defineConfig([
-    globalIgnores(['dist/*', 'node_modules/*', 'build/*']),
+export default [
+    { ignores: ['dist/*', 'types/*', 'node_modules/*', 'examples/*'] },
+
+    js.configs.recommended,
+    ...typescriptPlugin.configs['flat/recommended'],
+
     {
-        files: ['**/*.ts', '**/*.tsx'], // Include TypeScript and Vue files
+        files: ['**/*.ts'],
         languageOptions: {
-            parser: typescriptParser, // Use vue-eslint-parser for Vue files\
-        },
-        plugins: {
-            '@typescript-eslint': typescriptPlugin,
-        },
-        settings: {
-            'import/resolver': {
-                node: {
-                    extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
-                },
-            },
+            parser: typescriptParser,
         },
         rules: {
-            // TypeScript rules
-            '@typescript-eslint/ban-ts-comment': 'off',
-            '@typescript-eslint/explicit-function-return-type': 'off',
-            '@typescript-eslint/explicit-module-boundary-types': 'off',
-            '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
+            // The d3 selection/datum generics are impractical to spell out for
+            // every callback, so `any` stays allowed. Revisit if the d3 typings
+            // ever make this cheap.
             '@typescript-eslint/no-explicit-any': 'off',
+            // The visualizations reach into DOM nodes that d3 hands back as
+            // possibly-null; asserting is the idiomatic way to use that API.
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-var-requires': 'off',
+            // Empty arrow functions are the natural "no-op" default for the
+            // optional event callbacks in the settings objects.
+            '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
+            // `@ts-ignore` is silently a no-op once the code below it type-checks
+            // again, so it hides rot; `@ts-expect-error` fails the build instead.
+            // Descriptions are not required: the existing suppressions are almost
+            // all "the d3 typings do not model this", which adds no information.
+            '@typescript-eslint/ban-ts-comment': ['error', {
+                'ts-expect-error': false,
+                'ts-ignore': true,
+                'ts-nocheck': true,
+                'ts-check': false,
+            }],
+            // d3 hands callbacks a fixed (datum, index, groups) signature and
+            // event handlers a fixed (event, datum) one, so an argument often
+            // only exists to reach the one after it. Prefix those with `_`.
+            '@typescript-eslint/no-unused-vars': ['error', {
+                argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
+                caughtErrorsIgnorePattern: '^_',
+            }],
         },
     },
-    {
-        files: ['**/*.js'], // Separate rules for JavaScript files
-        rules: {
-            '@typescript-eslint/no-unused-vars': 'off', // Disable unused var check for JS
-        },
-    },
-]);
+];

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     ],
     "scripts": {
         "test": "vitest run",
+        "lint": "eslint \"src/**/*.ts\"",
+        "typecheck": "tsc --noEmit",
         "build": "vite build",
         "prepack": "npm run build",
         "dev": "vite",
@@ -42,7 +44,6 @@
         "canvas": "^3.1.0",
         "core-js": "^3.8.1",
         "eslint": "^9.0.0",
-        "eslint-define-config": "^2.1.0",
         "flush-promises": "^1.0.2",
         "jsdom": "^26.1.0",
         "pixelmatch": "^7.1.0",

--- a/src/color/ColorUtils.ts
+++ b/src/color/ColorUtils.ts
@@ -8,7 +8,7 @@ export default class ColorUtils {
         let textColor = "#000";
         try {
             textColor = ColorUtils.brightness(rgb(color)) < 125 ? "#eee" : "#000";
-        } catch (err) { /* go on */ }
+        } catch { /* go on */ }
         return textColor;
     }
 

--- a/src/test/TestDataGenerator.ts
+++ b/src/test/TestDataGenerator.ts
@@ -1,6 +1,6 @@
 export default class TestDataGenerator {
     public generateSmall2DDataset(): number[][] {
-        let data: number[][] = [];
+        const data: number[][] = [];
         data.push([1, 1]);
         data.push([1, 1.2]);
         data.push([2.5, 0.75]);

--- a/src/test/TestUtils.ts
+++ b/src/test/TestUtils.ts
@@ -1,4 +1,4 @@
-const flushPromises = require("flush-promises");
+import flushPromises from "flush-promises";
 
 export function sleep(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms));

--- a/src/transition/Transition.ts
+++ b/src/transition/Transition.ts
@@ -1,3 +1,6 @@
+// `Transition.easeX` is part of the published API, so turning this namespace
+// into a module would be a breaking change for consumers.
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Transition {
     /**
      * A transition that starts slowly, then accelerates and ends slowly again.

--- a/src/utilities/StringUtils.ts
+++ b/src/utilities/StringUtils.ts
@@ -4,7 +4,7 @@ export default class StringUtils {
      */
     static stringHash(s: string): number {
         return s.split("").reduce(function(a, b) {
-            let c = ((a << 5) - a) + b.charCodeAt(0);
+            const c = ((a << 5) - a) + b.charCodeAt(0);
             return c & c;
         }, 0);
     }

--- a/src/utilities/__tests__/NodeUtils.spec.ts
+++ b/src/utilities/__tests__/NodeUtils.spec.ts
@@ -39,7 +39,7 @@ describe("NodeUtils.isParentOf", () => {
         const parent = hierarchy;
         const child = hierarchy.children[0].children[1].children[0];
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(NodeUtils.isParentOf(parent, child, 4)).toBeTruthy();
     });
 
@@ -47,7 +47,7 @@ describe("NodeUtils.isParentOf", () => {
         const parent = hierarchy;
         const child = hierarchy.children[0].children[1].children[0];
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(NodeUtils.isParentOf(parent, child, 3)).toBeFalsy();
     });
 
@@ -59,7 +59,7 @@ describe("NodeUtils.isParentOf", () => {
             children: []
         };
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(NodeUtils.isParentOf(parent, child, 5)).toBeFalsy();
     });
 });

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -3,7 +3,6 @@ import * as d3 from "d3";
 import {Bar, BarItem} from "./Bar";
 import BarplotPreprocessor from "./BarplotPreprocessor";
 import TooltipUtilities from "../../utilities/TooltipUtilities";
-import DataNode from "../../DataNode";
 
 export default class Barplot {
     private readonly settings: BarplotSettings;
@@ -138,10 +137,10 @@ export default class Barplot {
         const svgGElement = visElement.append("g");
 
         // Prepare data
-        const stackedData = d3.stack<Bar, string>()
+        const stack = d3.stack<Bar, string>()
             .keys(Array.from(new Set(this.data.flatMap(bar => bar.items.map(item => item.label)))))
-            .value((d, key) => d.items.find(item => item.label === key)?.counts ?? 0)
-            (this.data);
+            .value((d, key) => d.items.find(item => item.label === key)?.counts ?? 0);
+        const stackedData = stack(this.data);
 
         // Scales
         const xScale = d3.scaleLinear()
@@ -212,7 +211,9 @@ export default class Barplot {
         }
 
         // Instead of keeping track of n values per entry, we want to keep track of n bars with the entries
-        const transposedStackedData = Array(this.data.length).fill(null).map(_ => new Array());
+        type StackedSegment = { barIndex: number, title: string, shape: d3.SeriesPoint<Bar> };
+        const transposedStackedData: StackedSegment[][] =
+            Array.from({ length: this.data.length }, () => []);
 
         for (const entry of stackedData) {
             const entryTitle = entry.key;
@@ -282,15 +283,15 @@ export default class Barplot {
             .attr("data-bar-item", (d) => d.title)
             .on("mouseover", (event: MouseEvent, d: any) => {
                 const itemIdx = this.data[d.barIndex].items.findIndex((item: BarItem) => item.label === d.title)!;
-                this.mouseIn(event, d.barIndex, itemIdx, (event.target! as HTMLElement).parentElement!);
+                this.mouseIn(event, d.barIndex, itemIdx);
             })
             .on("mousemove", (event: MouseEvent, d: any) => {
                 const itemIdx = this.data[d.barIndex].items.findIndex((item: BarItem) => item.label === d.title)!;
-                this.mouseMove(event, d.barIndex, itemIdx, (event.target! as HTMLElement).parentElement!);
+                this.mouseMove(event, d.barIndex, itemIdx);
             })
             .on("mouseout", (event: MouseEvent, d: any) => {
                 const itemIdx = this.data[d.barIndex].items.findIndex((item: BarItem) => item.label === d.title)!;
-                this.mouseOut(event, d.barIndex, itemIdx, (event.target! as HTMLElement).parentElement!);
+                this.mouseOut(event, d.barIndex, itemIdx);
             });
 
         // Add x-axis
@@ -350,7 +351,7 @@ export default class Barplot {
     }
 
     private initCss() {
-        let elementClass = this.settings.className;
+        const elementClass = this.settings.className;
         this.element.className += " " + elementClass;
 
         const styleElement = this.element.ownerDocument.createElement("style");
@@ -369,7 +370,7 @@ export default class Barplot {
         this.element.ownerDocument.head.appendChild(styleElement);
     }
 
-    private mouseIn(event: MouseEvent, barIndex: number, itemIndex: number, targetElement: EventTarget) {
+    private mouseIn(event: MouseEvent, barIndex: number, itemIndex: number) {
         const d = this.data[barIndex].items[itemIndex];
 
         this.settings.mouseIn(this.data, barIndex, itemIndex, {x: event.clientX, y: event.clientY});
@@ -394,7 +395,7 @@ export default class Barplot {
         }
     }
 
-    private mouseMove(event: MouseEvent, barIndex: number, itemIndex: number, targetElement: EventTarget) {
+    private mouseMove(event: MouseEvent, barIndex: number, itemIndex: number) {
         this.settings.mouseMove(this.data, barIndex, itemIndex, {x: event.clientX, y: event.clientY})
 
         if (this.settings.enableTooltips && this.tooltip) {
@@ -404,7 +405,7 @@ export default class Barplot {
         }
     }
 
-    private mouseOut(event: MouseEvent, barIndex: number, itemIndex: number, targetElement: EventTarget) {
+    private mouseOut(event: MouseEvent, barIndex: number, itemIndex: number) {
         this.settings.mouseOut(this.data, barIndex, itemIndex)
 
         if (this.settings.enableTooltips && this.tooltip) {

--- a/src/visualizations/barplot/BarplotSettings.ts
+++ b/src/visualizations/barplot/BarplotSettings.ts
@@ -1,5 +1,4 @@
 import Settings, {VisualizationPadding} from "../../Settings";
-import DataNode from "../../DataNode";
 import {Bar, BarItem} from "./Bar";
 
 export class BarplotChartSettings {

--- a/src/visualizations/heatmap/Heatmap.ts
+++ b/src/visualizations/heatmap/Heatmap.ts
@@ -109,7 +109,7 @@ export default class Heatmap {
         // Add a canvas to the desired element and set it's required properties
         this.element.innerHTML = "";
 
-        // @ts-ignore
+        // @ts-expect-error
         this.visElement = d3.select(this.element)
             .append("canvas")
             .attr("width", this.pixelRatio * this.settings.width)
@@ -129,7 +129,7 @@ export default class Heatmap {
                 this.zoomed(event.transform);
             });
 
-        // @ts-ignore
+        // @ts-expect-error
         this.visElement.call(zoom);
 
         this.computeClusterRoots();
@@ -138,7 +138,7 @@ export default class Heatmap {
     }
 
     private fillOptions(options: any = undefined): HeatmapSettings {
-        let output = new HeatmapSettings();
+        const output = new HeatmapSettings();
         return Object.assign(output, options);
     }
 
@@ -186,7 +186,7 @@ export default class Heatmap {
         const preprocessor = new Preprocessor();
 
         let rowOrder: number[] = Array.from(Array(this.rows.length).keys())
-        let inverseRowOrder: number[] = new Array(rowOrder.length);
+        const inverseRowOrder: number[] = new Array(rowOrder.length);
 
         if ((toCluster === "all" || toCluster === "rows") && !this.clusteredVertical) {
             this.clusteredVertical = true;
@@ -203,7 +203,7 @@ export default class Heatmap {
             await createAnimator(inverseRowOrder, columnIdentity);
             this.animatingRows = false;
 
-            let newValues = [];
+            const newValues = [];
             // Swap rows into the correct position
             for (const row of rowOrder) {
                 newValues.push(this.values[row]);
@@ -221,7 +221,7 @@ export default class Heatmap {
         }
 
         let columnOrder: number[] = Array.from(Array(this.columns.length).keys())
-        let inverseColumnOrder: number[] = new Array(columnOrder.length);
+        const inverseColumnOrder: number[] = new Array(columnOrder.length);
 
         if ((toCluster === "all" || toCluster === "columns") && !this.clusteredHorizontal) {
             this.clusteredHorizontal = true;
@@ -237,10 +237,10 @@ export default class Heatmap {
             await createAnimator(rowIdentity, inverseColumnOrder);
             this.animatingCols = false;
 
-            let newValues = [];
+            const newValues = [];
             // Swap columns
             for (const row of rowIdentity) {
-                let newRow: HeatmapValue[] = [];
+                const newRow: HeatmapValue[] = [];
                 for (const column of columnOrder) {
                     newRow.push(this.values[row][column]);
                 }
@@ -262,12 +262,12 @@ export default class Heatmap {
     }
 
     private computeClusterRoots() {
-        let clusterer = this.settings.clusteringAlgorithm;
-        let molo: Reorderer = this.settings.reorderer;
+        const clusterer = this.settings.clusteringAlgorithm;
+        const molo: Reorderer = this.settings.reorderer;
 
         // Create a new ClusterElement for every row that exists. This ClusterElement keeps track of an array of
         // numbers that correspond to a row's values.
-        let rowElements: ClusterElement[] = this.rows.map((el, idx) => new ClusterElement(
+        const rowElements: ClusterElement[] = this.rows.map((el, idx) => new ClusterElement(
             this.values[idx].filter(val => val.rowId == el.idx).map(x => x.value), el.idx!)
         );
 
@@ -275,7 +275,7 @@ export default class Heatmap {
         this.verticalNodesPerDepth = this.bfsNodesPerDepth(this.rowClusterRoot);
 
         // Create a new ClusterElement for every column that exists.
-        let columnElements: ClusterElement[] = this.columns.map(
+        const columnElements: ClusterElement[] = this.columns.map(
             (el, idx) => new ClusterElement(
                 this.values.map(col => col[idx].value),
                 el.idx!
@@ -343,7 +343,7 @@ export default class Heatmap {
         const offscreenCanvas = new OffscreenCanvas(1, 1);
         const ctx = offscreenCanvas.getContext("2d");
 
-        //@ts-ignore
+        // @ts-expect-error
         ctx!.font = `${fontSize}px 'Helvetica Neue', Helvetica, Arial, sans-serif`;
 
         // Then add the row and colum titles to the heatmap
@@ -368,7 +368,7 @@ export default class Heatmap {
             `;
 
             // Compute the length of the label in pixels
-            // @ts-ignore
+            // @ts-expect-error
             const computedWidth: number = ctx!.measureText(this.rows[row].name).width + x;
             if (computedWidth > maximumWidth) {
                 maximumWidth = computedWidth;
@@ -395,7 +395,7 @@ export default class Heatmap {
                 </text>
             `;
 
-            // @ts-ignore
+            // @ts-expect-error
             const computedWidth: number = ctx!.measureText(this.columns[col].name).width + y;
             if (computedWidth > maximumHeight) {
                 maximumHeight = computedWidth;
@@ -441,8 +441,8 @@ export default class Heatmap {
             textHeight;
 
         // Squares should at least be one pixel in height
-        let squareWidth = Math.max(1, visualizationWidth / this.columns.length);
-        let squareHeight = Math.max(1, visualizationHeight / this.rows.length);
+        const squareWidth = Math.max(1, visualizationWidth / this.columns.length);
+        const squareHeight = Math.max(1, visualizationHeight / this.rows.length);
 
         return Math.min(squareWidth, squareHeight);
     }
@@ -549,7 +549,7 @@ export default class Heatmap {
             animationStep = 0;
         }
 
-        let squareWidth = this.determineSquareWidth();
+        const squareWidth = this.determineSquareWidth();
         const dendrogramWidth: number = this.determineDendrogramWidth();
 
         this.context.clearRect(0, 0, this.settings.width, this.settings.height);
@@ -570,10 +570,10 @@ export default class Heatmap {
                 const xDifference = xTopEnd - xTopStart;
                 const yDifference = yTopEnd - yTopStart;
 
-                let xTopCurrent = xTopStart + xDifference * animationStep;
-                let yTopCurrent = yTopStart + yDifference * animationStep;
-                let xBottomCurrent = xTopCurrent + (squareWidth + this.settings.squarePadding);
-                let yBottomCurrent = yTopCurrent + (squareWidth + this.settings.squarePadding);
+                const xTopCurrent = xTopStart + xDifference * animationStep;
+                const yTopCurrent = yTopStart + yDifference * animationStep;
+                const xBottomCurrent = xTopCurrent + (squareWidth + this.settings.squarePadding);
+                const yBottomCurrent = yTopCurrent + (squareWidth + this.settings.squarePadding);
 
                 // We do not need to draw the current square
                 if (xBottomCurrent < 0 || xTopCurrent > this.settings.width) {
@@ -698,13 +698,13 @@ export default class Heatmap {
             animationStep = 0;
         }
 
-        let squareWidth = this.determineSquareWidth();
+        const squareWidth = this.determineSquareWidth();
         const dendrogramWidth = this.determineDendrogramWidth();
 
         // Per how many items should we display a text item? (padding is 8)
-        let stepSize: number = Math.max(Math.floor((this.settings.fontSize + 12) / (squareWidth + this.settings.squarePadding)), 1);
+        const stepSize: number = Math.max(Math.floor((this.settings.fontSize + 12) / (squareWidth + this.settings.squarePadding)), 1);
 
-        let textStart = this.computeTextStartY();
+        const textStart = this.computeTextStartY();
         let textCenter = Math.max((squareWidth - this.settings.fontSize) / 2, 0);
 
         this.context.save();
@@ -970,7 +970,7 @@ export default class Heatmap {
 
     private tooltipMove(event: MouseEvent) {
         // Find out which element is situated under the current mouse position.
-        // @ts-ignore
+        // @ts-expect-error
         const rect = event.target.getBoundingClientRect();
         const [row, col] = this.findRowAndColForPosition(event.clientX - rect.left, event.clientY - rect.top);
 
@@ -1018,7 +1018,7 @@ export default class Heatmap {
         const dendroWidth = this.determineDendrogramWidth();
         const squareWidth = this.determineSquareWidth();
 
-        // @ts-ignore
+        // @ts-expect-error
         const rect = event.target.getBoundingClientRect();
         const x = event.clientX - rect.left;
         const y = event.clientY - rect.top;

--- a/src/visualizations/heatmap/__tests__/Heatmap.spec.ts
+++ b/src/visualizations/heatmap/__tests__/Heatmap.spec.ts
@@ -1,7 +1,7 @@
 import HeatmapSettings from "./../HeatmapSettings";
 import Heatmap from "./../Heatmap";
 import { JSDOM } from "jsdom";
-import { sleep, waitForCondition } from "./../../../test/TestUtils";
+import { waitForCondition } from "./../../../test/TestUtils";
 import TestConsts from "./../../../test/TestConsts";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 
@@ -139,7 +139,7 @@ describe("Heatmap", () => {
         settings.minColor = "#ffebee";
         settings.maxColor = "#c62828";
 
-        const heatmap = await createHeatmap(jsDom, settings);
+        await createHeatmap(jsDom, settings);
 
         const image = await makeScreenshot(jsDom);
         expect(image).toMatchImageSnapshot(TestConsts.resolveImageSnapshotFolder(__filename));

--- a/src/visualizations/heatmap/cluster/TreeNode.ts
+++ b/src/visualizations/heatmap/cluster/TreeNode.ts
@@ -77,15 +77,13 @@ export default class TreeNode {
      * Convert this tree and all of it's children to the dot GraphViz-format.
      */
     public toGraphViz(nameExtractor: (id: number) => string): string {
-        let root: TreeNode | undefined = this;
-
         let output = "digraph dendrogram {\n";
         let labels = "";
         let edges = "";
 
-        let toCheck: TreeNode[] = [root];
+        const toCheck: TreeNode[] = [this];
         while (toCheck.length > 0) {
-            root = toCheck.shift();
+            const root = toCheck.shift();
 
             if (!root) {
                 break;

--- a/src/visualizations/heatmap/cluster/UPGMAClusterer.ts
+++ b/src/visualizations/heatmap/cluster/UPGMAClusterer.ts
@@ -29,13 +29,13 @@ export default class UPGMAClusterer implements Clusterer {
         }
 
         // All clusters that exist in a current step.
-        let clusters: Map<number, Cluster> = new Map();
+        const clusters: Map<number, Cluster> = new Map();
 
         // Now we need to compute a distance matrix. A distance matrix needs a matrix with raw values to be calculated.
         // We thus need to convert the input into a value matrix, before proceeding.
-        let valueMatrix: number[][] = [];
+        const valueMatrix: number[][] = [];
         for (let i = 0; i < data.length; i++) {
-            let row: number[] = data[i].values;
+            const row: number[] = data[i].values;
             clusters.set(i, new Cluster([data[i]], i, new TreeNode(null, null, null, [data[i]], 0)));
             valueMatrix.push(row);
         }
@@ -50,8 +50,8 @@ export default class UPGMAClusterer implements Clusterer {
             let smallestDistance = Infinity;
             let x = -1;
             let y = -1;
-            for (let i of clusters.keys()) {
-                for (let j of clusters.keys()) {
+            for (const i of clusters.keys()) {
+                for (const j of clusters.keys()) {
                     if (i > j) {
                         if (distanceMatrix[i][j] < smallestDistance) {
                             smallestDistance = distanceMatrix[i][j];
@@ -63,20 +63,20 @@ export default class UPGMAClusterer implements Clusterer {
             }
 
             // Get the cluster objects corresponding to the closest distance found.
-            let xCluster = clusters.get(x);
-            let yCluster = clusters.get(y);
+            const xCluster = clusters.get(x);
+            const yCluster = clusters.get(y);
 
-            let nodeHeight: number = smallestDistance / 2;
+            const nodeHeight: number = smallestDistance / 2;
 
             if (!xCluster || !yCluster) {
                 throw "At least one cluster is invalid!";
             }
 
             // Recalculate distance from this cluster to other clusters (Use average distance)
-            let updatedDistanceMatrix: number[][] = this.copyDistanceMatrix(distanceMatrix);
+            const updatedDistanceMatrix: number[][] = this.copyDistanceMatrix(distanceMatrix);
 
             // Cluster.keys() returns a reference to every cluster at the current step
-            for (let j of clusters.keys()) {
+            for (const j of clusters.keys()) {
                 if (j != x && j != y) {
                     // Our matrix is lower triangular (because it is symmetric). This means we should extract the value
                     // from the right part of the matrix.
@@ -95,7 +95,7 @@ export default class UPGMAClusterer implements Clusterer {
                     }
 
                     // Recalculate the distance between the new, merged cluster and all other clusters.
-                    let temp = (xCluster.elements.length * xDistance + yCluster.elements.length * yDistance) / (xCluster.elements.length + yCluster.elements.length);
+                    const temp = (xCluster.elements.length * xDistance + yCluster.elements.length * yDistance) / (xCluster.elements.length + yCluster.elements.length);
                     if (j > x) {
                         updatedDistanceMatrix[j][x] = temp;
                     } else {
@@ -117,11 +117,11 @@ export default class UPGMAClusterer implements Clusterer {
     }
 
     private copyDistanceMatrix(distanceMatrix: number[][]): number[][] {
-        let output: number[][] = [];
+        const output: number[][] = [];
 
         for (let i = 0; i < distanceMatrix.length; i++) {
-            let current: number[] = [];
-            let row = distanceMatrix[i];
+            const current: number[] = [];
+            const row = distanceMatrix[i];
             for (let j = 0; j < row.length; j++) {
                 current.push(row[j]);
             }

--- a/src/visualizations/heatmap/metric/EuclidianDistanceMetric.ts
+++ b/src/visualizations/heatmap/metric/EuclidianDistanceMetric.ts
@@ -2,10 +2,10 @@ import { Metric } from "./Metric";
 
 export default class EuclidianDistanceMetric implements Metric {
     getDistance(matrix: number[][]): number[][] {
-        let output: number[][] = [];
+        const output: number[][] = [];
 
         for (let i = 0; i < matrix.length; i++) {
-            let row: number[] = [];
+            const row: number[] = [];
             for (let j = 0; j <= i; j++) {
                 row.push(this.calculateEuclideanDistance(matrix[i], matrix[j]))
             }

--- a/src/visualizations/heatmap/metric/Metric.ts
+++ b/src/visualizations/heatmap/metric/Metric.ts
@@ -1,4 +1,3 @@
-import ClusterElement from "../cluster/ClusterElement";
 
 export interface Metric {
     /**

--- a/src/visualizations/heatmap/metric/PearsonCorrelationMetric.ts
+++ b/src/visualizations/heatmap/metric/PearsonCorrelationMetric.ts
@@ -2,10 +2,10 @@ import { Metric } from "./Metric";
 
 export default class PearsonCorrelationMetric implements Metric {
     getDistance(matrix: number[][]): number[][] {
-        let output: number[][] = [];
+        const output: number[][] = [];
 
         for (let i = 0; i < matrix.length; i++) {
-            let row: number[] = [];
+            const row: number[] = [];
             for (let j = 0; j <= i; j++) {
                 row.push(this.getPearsonCorrelationBetween2Samples(matrix[i], matrix[j]));
             }

--- a/src/visualizations/heatmap/reorder/MoloReorderer.ts
+++ b/src/visualizations/heatmap/reorder/MoloReorderer.ts
@@ -21,19 +21,19 @@ export default class MoloReorderer implements Reorderer {
             return root;
         }
 
-        let leftTree: TreeNode = root.leftChild;
-        let rightTree: TreeNode = root.rightChild;
+        const leftTree: TreeNode = root.leftChild;
+        const rightTree: TreeNode = root.rightChild;
 
-        let leftSingleton: boolean = !leftTree.leftChild && !leftTree.rightChild;
-        let rightSingleton: boolean = !rightTree.leftChild && !rightTree.rightChild;
+        const leftSingleton: boolean = !leftTree.leftChild && !leftTree.rightChild;
+        const rightSingleton: boolean = !rightTree.leftChild && !rightTree.rightChild;
 
         if (leftSingleton && rightSingleton) {
             this.nodeMinMap.set(root, root.height);
         } else if (!leftSingleton && rightSingleton) {
-            let sorted: TreeNode = this.sortMinimum(leftTree);
+            const sorted: TreeNode = this.sortMinimum(leftTree);
             root.leftChild = sorted;
 
-            let sortedMin = this.nodeMinMap.get(sorted);
+            const sortedMin = this.nodeMinMap.get(sorted);
 
             if (sortedMin === undefined) {
                 throw "The recursive call to sort the left subtree did not yield a minimum value.";
@@ -41,11 +41,11 @@ export default class MoloReorderer implements Reorderer {
 
             this.nodeMinMap.set(root, Math.min(root.height, sortedMin));
         } else if (leftSingleton && !rightSingleton) {
-            let sorted: TreeNode = this.sortMinimum(rightTree);
+            const sorted: TreeNode = this.sortMinimum(rightTree);
             root.leftChild = sorted;
             root.rightChild = leftTree;
 
-            let sortedMin = this.nodeMinMap.get(sorted);
+            const sortedMin = this.nodeMinMap.get(sorted);
 
             if (sortedMin === undefined) {
                 throw "The recursive call to sort the right subtree did not yield a minimum value.";
@@ -54,11 +54,11 @@ export default class MoloReorderer implements Reorderer {
             this.nodeMinMap.set(root, Math.min(root.height, sortedMin));
         } else  {
             // Both trees are non-leaves
-            let leftSorted: TreeNode = this.sortMinimum(leftTree);
-            let rightSorted: TreeNode = this.sortMinimum(rightTree);
+            const leftSorted: TreeNode = this.sortMinimum(leftTree);
+            const rightSorted: TreeNode = this.sortMinimum(rightTree);
 
-            let leftMin = this.nodeMinMap.get(leftSorted);
-            let rightMin = this.nodeMinMap.get(rightSorted);
+            const leftMin = this.nodeMinMap.get(leftSorted);
+            const rightMin = this.nodeMinMap.get(rightSorted);
 
             if (leftMin === undefined || rightMin === undefined) {
                 throw "One of the recursive calls to sort a subtree did not yield a minimum value.";

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -74,7 +74,7 @@ export default class Sunburst {
 
         // Prepare element and create SVG container
         this.element.innerHTML = "";
-        // @ts-ignore
+        // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)
             .append("div")
             .attr("id", Math.floor(Math.random() * 2**16) + "-breadcrumbs")
@@ -95,7 +95,7 @@ export default class Sunburst {
             .attr("type", "text/css")
             .html(".hidden{ visibility: hidden;}");
 
-        // @ts-ignore
+        // @ts-expect-error
         this.visGElement = visElement.append("g")
             // set origin to radius center
             .attr("transform", "translate(" + this.settings.radius + "," + this.settings.radius + ")");
@@ -182,7 +182,7 @@ export default class Sunburst {
     }
 
     private initCss() {
-        let elementClass = this.settings.className;
+        const elementClass = this.settings.className;
         this.element.className += " " + elementClass;
 
         const styleElement = this.element.ownerDocument.createElement("style");
@@ -230,7 +230,7 @@ export default class Sunburst {
      * @return new scales
      */
     private arcTween(d: HRN<DataNode>, that: any): any {
-        let my = Math.min(this.maxY(d), d.y0 + that.settings.levels * (d.y1 - d.y0)),
+        const my = Math.min(this.maxY(d), d.y0 + that.settings.levels * (d.y1 - d.y0)),
             xd = d3.interpolate(that.xScale.domain(), [d.x0, d.x1]),
             yd = d3.interpolate(that.yScale.domain(), [d.y0, my]),
             yr = d3.interpolate(that.yScale.range(), [d.y0 ? 20 : 0, that.settings.radius]);
@@ -257,7 +257,7 @@ export default class Sunburst {
         }
     }
 
-    private tooltipMove(event: MouseEvent, d: HRN<DataNode>) {
+    private tooltipMove(event: MouseEvent, _d: HRN<DataNode>) {
         if (this.settings.enableTooltips && this.tooltip) {
             this.tooltip
                 .style("top", (event.pageY + 10) + "px")
@@ -265,7 +265,7 @@ export default class Sunburst {
         }
     }
 
-    private tooltipOut(event: MouseEvent, d: HRN<DataNode>) {
+    private tooltipOut(_event: MouseEvent, _d: HRN<DataNode>) {
         if (this.settings.enableTooltips && this.tooltip) {
             this.tooltip.style("visibility", "hidden");
         }
@@ -392,7 +392,10 @@ export default class Sunburst {
             data.splice(data.indexOf(parentNode.parent), 1);
         }
 
-        // hack for the getComputedTextLength
+        // The font-size callback below has to be a `function` so that d3 binds
+        // `this` to the <text> element for getComputedTextLength, which leaves it
+        // no way to reach the Sunburst instance except through an alias.
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
         const that = this;
 
         const offscreenCanvasSupported = typeof OffscreenCanvas !== "undefined";
@@ -400,7 +403,7 @@ export default class Sunburst {
         let ctx: OffscreenCanvasRenderingContext2D;
         if (offscreenCanvasSupported) {
             const offscreenCanvas = new OffscreenCanvas(1, 1);
-            // @ts-ignore
+            // @ts-expect-error
             ctx = offscreenCanvas.getContext("2d")!;
             ctx.font = ctx!.font = "16px 'Helvetica Neue', Helvetica, Arial, sans-serif"
         }
@@ -416,7 +419,7 @@ export default class Sunburst {
             .style("pointer-events", "none") // don't invoke mouse events
             .attr("dy", ".2em")
             .text((d: HRN<DataNode>) => this.settings.getLabel(d.data))
-            .style("font-size", function(this: SVGTextContentElement, d: HRN<DataNode>) {
+            .style("font-size", function(this: SVGTextContentElement, _d: HRN<DataNode>) {
                 const txtLength = offscreenCanvasSupported ? ctx.measureText(this.textContent!).width : this.getComputedTextLength();
                 return Math.floor(Math.min(((that.settings.radius / that.settings.levels) / txtLength * 10) + 1, 12)) + "px";
             });
@@ -426,14 +429,14 @@ export default class Sunburst {
             this.text
                 .transition().duration(this.settings.animationDuration)
                 .attrTween("text-anchor", (d: HRN<DataNode>) => {
-                    return (t: number) => this.xScale(d.x0 + (d.x1 - d.x0) / 2) > Math.PI ? "end" : "start";
+                    return (_t: number) => this.xScale(d.x0 + (d.x1 - d.x0) / 2) > Math.PI ? "end" : "start";
                 })
                 .attrTween("dx", (d: HRN<DataNode>) => {
-                    return (t: number) => this.xScale(d.x0 + (d.x1 - d.x0) / 2) > Math.PI ? "-4px" : "4px";
+                    return (_t: number) => this.xScale(d.x0 + (d.x1 - d.x0) / 2) > Math.PI ? "-4px" : "4px";
                 })
                 .attrTween("transform", (d: HRN<DataNode>) => {
-                    return (t: number) => {
-                        let angle = this.xScale(d.x0 + (d.x1 - d.x0) / 2) * 180 / Math.PI - 90;
+                    return (_t: number) => {
+                        const angle = this.xScale(d.x0 + (d.x1 - d.x0) / 2) * 180 / Math.PI - 90;
                         return `rotate(${angle})translate(${this.yScale(d.y0)})rotate(${angle > 90 ? -180 : 0})`;
                     }
                 })
@@ -468,7 +471,7 @@ export default class Sunburst {
 
     private setBreadcrumbs(d: HRN<DataNode>) {
         // First find out which nodes we encounter on the path from the root node to the clicked node.
-        let crumbs: HRN<DataNode>[] = [];
+        const crumbs: HRN<DataNode>[] = [];
         let temp: (HRN<DataNode> | null) = d;
 
         while (temp) {

--- a/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
+++ b/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
@@ -32,7 +32,7 @@ describe("Sunburst", () => {
         // Animations need to be disabled during the tests
         settings["animationDuration"] = 0;
 
-        const sunburst = new Sunburst(element, taxonomyObject, settings);
+        new Sunburst(element, taxonomyObject, settings);
 
         await waitForCondition(() => element.innerHTML.includes("svg"), 3000, 500);
 
@@ -74,7 +74,7 @@ describe("Sunburst", () => {
         const settings = new SunburstSettings();
         settings.animationDuration = 0;
 
-        const sunburst = new Sunburst(element, taxonomyObject, settings);
+        new Sunburst(element, taxonomyObject, settings);
 
         await waitForCondition(() => element.innerHTML.includes("svg"), 2000, 500);
 
@@ -109,7 +109,7 @@ describe("Sunburst", () => {
         settings.animationDuration = 0;
         settings.rerootCallback = (d: DataNode) => nodeFromCallback = d;
 
-        const sunburst = new Sunburst(element, taxonomyObject, settings);
+        new Sunburst(element, taxonomyObject, settings);
 
         await waitForCondition(() => element.innerHTML.includes("svg"), 2000, 500);
 

--- a/src/visualizations/treemap/Treemap.ts
+++ b/src/visualizations/treemap/Treemap.ts
@@ -62,12 +62,12 @@ export default class Treemap {
 
         this.colorScale =  d3.scaleLinear()
             .domain([0, this.settings.levels])
-            // @ts-ignore
+            // @ts-expect-error
             .range([this.settings.colorRoot, this.settings.colorLeaf])
-            // @ts-ignore
+            // @ts-expect-error
             .interpolate(d3.interpolateLab);
 
-        // @ts-ignore
+        // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)
             .append("div")
             .attr("class", "breadcrumbs")
@@ -121,7 +121,7 @@ export default class Treemap {
     }
 
     private initCss() {
-        let elementClass = this.settings.className;
+        const elementClass = this.settings.className;
         this.element.className += " " + elementClass;
 
         const styleElement = this.element.ownerDocument.createElement("style");
@@ -177,7 +177,7 @@ export default class Treemap {
 
         rootNode.sort((a: d3.HierarchyNode<DataNode>, b: d3.HierarchyNode<DataNode>) => b.value! - a.value!);
 
-        let nodes = this.treemap.selectAll<d3.BaseType, HRN<DataNode>>(".node")
+        const nodes = this.treemap.selectAll<d3.BaseType, HRN<DataNode>>(".node")
             .data(
                 this.partition(rootNode).descendants(),
                 (d: HRN<DataNode>) => d.data.id || (d.data.id = ++this.nodeId)
@@ -194,7 +194,7 @@ export default class Treemap {
             .style("height", "0px")
             .text((d: HRN<DataNode>) => this.settings.getLabel(d.data))
             .on("click", (event: MouseEvent, d: HRN<DataNode>) => this.render(d))
-            .on("contextmenu", (event: MouseEvent, d: HRN<DataNode>) => {
+            .on("contextmenu", (event: MouseEvent, _d: HRN<DataNode>) => {
                 event.preventDefault();
                 if (this.currentRoot.parent) {
                     this.render(this.currentRoot.parent);
@@ -204,7 +204,7 @@ export default class Treemap {
             .on("mousemove", (event: MouseEvent, d: HRN<DataNode>) => this.tooltipMove(event, d))
             .on("mouseout", (event: MouseEvent, d: HRN<DataNode>) => this.tooltipOut(event, d));
 
-        // @ts-ignore
+        // @ts-expect-error
         divNodes.merge(nodes)
             .order()
             .transition()
@@ -224,7 +224,7 @@ export default class Treemap {
     }
 
     private setBreadcrumbs() {
-        let crumbs: DataNode[] = [];
+        const crumbs: DataNode[] = [];
         let temp: DataNode | undefined = this.currentRoot.data;
         while (temp) {
             crumbs.push(temp);
@@ -254,7 +254,7 @@ export default class Treemap {
         }
     }
 
-    private tooltipMove(event: MouseEvent, d: HRN<DataNode>) {
+    private tooltipMove(event: MouseEvent, _d: HRN<DataNode>) {
         if (this.settings.enableTooltips && this.tooltip) {
             this.tooltip
                 .style("top", (event.pageY + 10) + "px")
@@ -262,7 +262,7 @@ export default class Treemap {
         }
     }
 
-    private tooltipOut(event: MouseEvent, d: HRN<DataNode>) {
+    private tooltipOut(_event: MouseEvent, _d: HRN<DataNode>) {
         if (this.settings.enableTooltips && this.tooltip) {
             this.tooltip.style("visibility", "hidden");
         }

--- a/src/visualizations/treemap/__tests__/Treemap.spec.ts
+++ b/src/visualizations/treemap/__tests__/Treemap.spec.ts
@@ -56,7 +56,7 @@ describe("Treemap", () => {
 
     it("should render a treemap with default settings", async() => {
         const jsDom = createJSDom();
-        const treemap = await createTreemap(jsDom, new TreemapSettings());
+        await createTreemap(jsDom, new TreemapSettings());
 
         const image = await makeScreenshot(jsDom);
         expect(image).toMatchImageSnapshot(TestConsts.resolveImageSnapshotFolder(__filename));
@@ -70,7 +70,7 @@ describe("Treemap", () => {
         const settings = new TreemapSettings();
         settings.rerootCallback = (d: DataNode) => nodeFromCallback = d;
 
-        const treemap = await createTreemap(jsDom, settings);
+        await createTreemap(jsDom, settings);
 
         expect(nodeFromCallback!.name).toEqual("root");
 

--- a/src/visualizations/treeview/Treeview.ts
+++ b/src/visualizations/treeview/Treeview.ts
@@ -5,7 +5,7 @@ import TreeviewNode from "./TreeviewNode";
 import MaxCountHeap from "./heap/MaxCountHeap";
 import TreeviewPreprocessor from "./TreeviewPreprocessor";
 import TooltipUtilities from "./../../utilities/TooltipUtilities";
-import DataNode, { DataNodeLike } from "./../../DataNode";
+import { DataNodeLike } from "./../../DataNode";
 
 type HPN<T> = d3.HierarchyPointNode<T>;
 type HPL<T> = d3.HierarchyPointLink<T>;
@@ -119,7 +119,7 @@ export default class Treeview {
             }
         }
 
-        this.root.children?.forEach((d: HPN<TreeviewNode>, i: number) => {
+        this.root.children?.forEach((d: HPN<TreeviewNode>, _i: number) => {
             updateColor(d, 1);
         });
 
@@ -160,7 +160,7 @@ export default class Treeview {
             const toExpand = pq.remove();
             allowedCount -= toExpand.data.count;
             toExpand.data.expand(1);
-            toExpand.children?.forEach((d: HPN<TreeviewNode>, i: number) => {
+            toExpand.children?.forEach((d: HPN<TreeviewNode>, _i: number) => {
                 pq.add(d);
             });
         }
@@ -179,7 +179,7 @@ export default class Treeview {
         const node = this.visElement.selectAll<d3.BaseType, HPN<TreeviewNode>>("g.node")
             .data(nodes, (d: HPN<TreeviewNode>) => d.data.id || (d.data.id = ++this.nodeId));
 
-        let nodeEnter = node.enter()
+        const nodeEnter = node.enter()
             .append("g")
             .attr("class", "node")
             .style("cursor", "pointer")
@@ -190,7 +190,7 @@ export default class Treeview {
             .on("mouseover", (event: MouseEvent, d: HPN<TreeviewNode>) => this.tooltipIn(event, d))
             .on("mouseout", (event: MouseEvent, d: HPN<TreeviewNode>) => this.tooltipOut(event, d))
             .on("contextmenu", (event: MouseEvent, d: HPN<TreeviewNode>) => this.rightClick(event, d))
-            // @ts-ignore
+            // @ts-expect-error
             .merge(node);
 
         nodeEnter.append("circle")
@@ -203,21 +203,20 @@ export default class Treeview {
 
         const innerArc = d3.arc()
             .innerRadius(0)
-            // @ts-ignore
+            // @ts-expect-error
             .outerRadius((d: HPN<TreeviewNode>) => {
                 return this.computeNodeSize(d);
             })
             .startAngle(0)
             .endAngle(d => {
-                // @ts-ignore
+                // @ts-expect-error
                 return arcScale(d.data.selfCount / d.data.count) || 0;
             });
 
         if (this.settings.enableInnerArcs) {
-            // @ts-ignore
             nodeEnter.append("path")
                 .attr("class", "innerArc")
-                // @ts-ignore
+                // @ts-expect-error
                 .attr("d", innerArc)
                 .style("fill", (d: HPN<TreeviewNode>) => this.settings.nodeStrokeColor(d.data))
                 .style("fill-opacity", 0);
@@ -258,7 +257,7 @@ export default class Treeview {
         // Animate the movement of every node that should be removed to the source node location.
         const nodeExit = node.exit().transition()
             .duration(this.settings.animationDuration)
-            .attr("transform", d => `translate(${source.y},${source.x})`)
+            .attr("transform", _d => `translate(${source.y},${source.x})`)
             .remove();
 
         nodeExit.select("circle")
@@ -271,14 +270,13 @@ export default class Treeview {
             .style("fill-opacity", 1e-6);
 
         // Update the links between the different nodes.
-        // @ts-ignore
-        let link = this.visElement.selectAll("path.link")
+        // @ts-expect-error
+        const link = this.visElement.selectAll("path.link")
             .data(links, (d: HPL<TreeviewNode>) => d.target.data.id);
 
         const linkGenerator = d3.linkHorizontal<any, HPL<TreeviewNode>, HPN<TreeviewNode>>().x(d => d.y).y(d => d.x);
 
         // Enter any new links at the parent's previous position.
-        // @ts-ignore
         link.enter()
             .insert("path", "g")
             .attr("class", "link")
@@ -287,20 +285,19 @@ export default class Treeview {
             .style("stroke-linecap", "round")
             .style("stroke", (d: HPL<TreeviewNode>) => this.settings.linkStrokeColor(d))
             .style("stroke-width", 1e-6)
-            // @ts-ignore
-            .attr("d", (d: HPL<TreeviewNode>) => {
+            .attr("d", (_d: HPL<TreeviewNode>) => {
                 const o = {
                     x: source.data.previousPosition.x,
                     y: source.data.previousPosition.y
                 }
 
-                // @ts-ignore
+                // @ts-expect-error
                 return linkGenerator({
                     source: o,
                     target: o
                 });
             })
-            // @ts-ignore
+            // @ts-expect-error
             .merge(link)
             .transition()
             .duration(this.settings.animationDuration)
@@ -318,14 +315,14 @@ export default class Treeview {
         link.exit().transition()
             .duration(this.settings.animationDuration)
             .style("stroke-width", 1e-6)
-            // @ts-ignore
-            .attr("d", (d: HPL<TreeviewNode>) => {
+            // @ts-expect-error
+            .attr("d", (_d: HPL<TreeviewNode>) => {
                 const o = {
                     x: source.x,
                     y: source.y
                 };
 
-                // @ts-ignore
+                // @ts-expect-error
                 return linkGenerator({
                     source: o,
                     target: o
@@ -381,7 +378,7 @@ export default class Treeview {
         }
     }
 
-    private tooltipOut(event: MouseEvent, d: HPN<TreeviewNode>) {
+    private tooltipOut(_event: MouseEvent, _d: HPN<TreeviewNode>) {
         if (this.settings.enableTooltips && this.tooltip) {
             clearTimeout(this.tooltipTimer);
             this.tooltip.style("visibility", "hidden");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "esModuleInterop": true,
         "sourceMap": true,
         "strict": true,
+        "skipLibCheck": true,
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "isolatedModules": true,


### PR DESCRIPTION
Stacked on #182.

`eslint.config.js` only ever set rules to `'off'`. It never extended a recommended config, so there were **zero active rules** and `eslint "src/**/*.ts"` reported nothing no matter what the source said. Every push since has collected a green Lint ✓ that could not have failed.

I confirmed it before changing anything by linting a file with an unused `any`, a `==` comparison and no semicolons: exit 0, no output. `@eslint/js` has been a devDependency this whole time without being imported.

## What changed

Extend `@eslint/js` and `typescript-eslint` recommended, then fix the 178 errors that surfaced:

| Rule | n | How |
| --- | ---: | --- |
| `prefer-const` | 66 | `--fix` |
| `no-unused-vars` | 34 | see below |
| `ban-ts-comment` | 29 | `@ts-ignore` → `@ts-expect-error` |
| `no-this-alias` | 2 | one rewritten, one suppressed with a reason |
| `no-namespace` | 1 | suppressed — `Transition` is published API |
| `no-require-imports` | 1 | `require("flush-promises")` → `import` |
| `no-unexpected-multiline` | 1 | named the `d3.stack()` generator instead of calling it off the end of the chain |
| `no-array-constructor` | 1 | `--fix`, then see the caveat below |

**Unused variables** split three ways. Dead imports (`DataNode` ×3, `ClusterElement`, `sleep`) and dead bindings (`const treemap = ...` where only the constructor's side effect was wanted) are gone. `Barplot`'s three private mouse handlers took a `targetElement` parameter none of them used, so the parameter and the three call sites that computed `(event.target! as HTMLElement).parentElement!` to feed it are gone too. The rest are d3's fixed positional signatures — an argument that exists only to reach the one after it — and now start with `_`, matching a new `argsIgnorePattern`.

## Two things worth reviewing

**Three `@ts-ignore`s were suppressing nothing.** Converting them to `@ts-expect-error` made `tsc` report `TS2578: Unused '@ts-expect-error' directive` at `Treeview.ts` 217, 281 and 290. Removed. This is the whole reason the swap is worth doing: `@ts-ignore` silently becomes a no-op once the code under it starts type-checking again, so it hides rot, while `@ts-expect-error` fails the build. I did **not** require descriptions on the remaining 26 — they are almost all "the d3 typings do not model this", and inventing 26 comments to that effect would add noise, not information.

**The `no-array-constructor` autofix introduced a type error.** `Array(n).fill(null).map(_ => new Array())` infers `any[][]`; the fixed `.map(() => [])` infers `never[][]`, which broke eight lines downstream in `Barplot`. Replaced with an explicitly typed `StackedSegment[][]` built by `Array.from`. Worth flagging because it is exactly the class of bug a lint-only CI job cannot catch — which is why:

## Type checking

Added `npm run typecheck`. It needed `skipLibCheck: true`, without which `tsc --noEmit` reports hundreds of errors inside `puppeteer`'s and `vitest`'s own `.d.ts` files and none in this package.

Also added `npm run lint`, so both run the same way locally and in CI. Wiring them into the workflows comes with the CI/release PR, which will replace `lint.yml` and `test.yml` wholesale.

## Deliberately left off

`no-explicit-any` (43 occurrences) and `no-non-null-assertion` — the d3 selection generics make both impractical, which is presumably why they were switched off originally. They stay off, but now with a written reason rather than being the entire config.

Dropped `eslint-define-config` from devDependencies; the flat config does not use it.

## Verified

`npm run lint`, `npm run typecheck` and `npm run build` all clean. `npm test`: 29 pass, unchanged from `main` — the 4 heatmap failures are local, `canvas`'s native module is not built in my sandbox, and they fail identically before these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### About the red ✗ Lint check

Pre-existing, and not caused by this PR — the same failure is on `main`:

```
ESLint: 10.8.1
TypeError: scopeManager.addGlobals is not a function
```

`lint.yml` runs `npm i -g eslint`, which installs whatever is newest — today ESLint **10.8.1** — while the repo pins `eslint ^9` and `@typescript-eslint` 8.x. The moment ESLint 10 shipped, that job went from "green but checking nothing" to "red for an unrelated reason". #184 deletes that workflow and runs the pinned local eslint via `npm run lint`; #188 moves the repo to ESLint 10 properly. The `Test` job is green here.
