### PR TITLE
Rewrite the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,119 @@
-# Unipept visualizations
-This repository contains stand-alone versions of the Unipept visualizations. At this time, a treeview, a treemap, a sunburst graph and a heatmap are available. The complete package has been written in TypeScript and uses D3 (v6) internally and is aimed at rendering vast amounts of data as fast as possible. Most visualizations are SVG-based, but an HTML Canvas has been used where necessary to make sure performance is as high as possible.
+# Unipept Visualizations
 
-![treeview example](examples/treeview-taxonomy.png)
+[![npm](https://img.shields.io/npm/v/unipept-visualizations)](https://www.npmjs.com/package/unipept-visualizations)
+[![CI](https://github.com/unipept/unipept-visualizations/actions/workflows/ci.yml/badge.svg)](https://github.com/unipept/unipept-visualizations/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/unipept-visualizations)](LICENSE.md)
 
-![treemap example](examples/treemap-taxonomy.png)
+Stand-alone, reusable versions of the visualizations built for [Unipept](https://unipept.ugent.be): a treeview, a treemap, a sunburst, a heatmap and a barplot. Written in TypeScript on top of [D3](https://d3js.org) 7 and aimed at rendering large datasets quickly — SVG and plain DOM where that is fast enough, an HTML canvas where it is not.
 
-![sunburst example](examples/sunburst-taxonomy.png)
+**[Try them in your browser →](https://unipept.github.io/unipept-visualizations/)**
 
-![heatmap example](examples/heatmap.png)
+| | |
+| --- | --- |
+| ![treeview](examples/treeview-taxonomy.png) | ![sunburst](examples/sunburst-taxonomy.png) |
+| ![treemap](examples/treemap-taxonomy.png) | ![barplot](examples/barplot-taxonomy.png) |
 
-## Requirements
-[D3.js](https://d3js.org/) (version 6.x should do) and is required to use these visualizations. The code is written using JavaScript ES2020 features, but a transpiled ES6-compatible version (`unipept-visualizations.js`) that should work in all modern browsers is available in the [`dist`](dist) directory.
+![heatmap](examples/heatmap.png)
 
-## Installation and use
-1. Download and include [`unipept-visualizations.min.js`](dist/unipept-visualizations.js) on your page
-2. Include D3
-3. Add a div with an id (for example `<div id="example"></div>`) to your page
-4. Initialize the treeview by invoking `treeview()` or `treemap()` with the div-element. For example `const treeview = new UnipeptVisualizations.Treeview(document.getElementById("example"), data, options);`
+## Installation
+
+```sh
+npm install unipept-visualizations
+```
+
+D3 is bundled into the published file, so you do not need to load it separately.
+
+## Usage
+
+Every visualization is a class that renders into an element you give it, and takes an optional settings object:
+
+```js
+import { Treeview } from "unipept-visualizations";
+
+new Treeview(document.getElementById("example"), data, {
+    width: 900,
+    height: 600,
+    colorProviderLevels: 3,
+});
+```
+
+`Treeview`, `Treemap` and `Sunburst` all take the same hierarchical data — a tree of nodes carrying at least a `count` and a `selfCount`, with `id`, `name` and `children` filled in for you when they are missing:
+
+```js
+const data = {
+    id: 1,
+    name: "root",
+    count: 12,
+    selfCount: 0,
+    children: [
+        { id: 2759, name: "Eukaryota", count: 7, selfCount: 2, children: [] },
+        { id: 2, name: "Bacteria", count: 5, selfCount: 5 },
+    ],
+};
+```
+
+`Barplot` takes an array of bars, each with a label and its items:
+
+```js
+import { Barplot } from "unipept-visualizations";
+
+new Barplot(document.getElementById("example"), [
+    { label: "Sample 7", items: [{ label: "Blautia obeum", counts: 1 }] },
+    { label: "Sample 8", items: [{ label: "Blautia obeum", counts: 4 }] },
+]);
+```
+
+`Heatmap` takes a matrix and its labels:
+
+```js
+import { Heatmap } from "unipept-visualizations";
+
+new Heatmap(document.getElementById("example"), values, rowLabels, columnLabels);
+```
+
+Without a bundler, import the package from a CDN as an ES module:
+
+```html
+<div id="example"></div>
+<script type="module">
+    import { Treeview } from "https://cdn.jsdelivr.net/npm/unipept-visualizations/+esm";
+    new Treeview(document.getElementById("example"), data);
+</script>
+```
 
 ## Documentation
-Head over to our [GitHub Wiki](https://github.com/unipept/unipept-visualizations/wiki) for the full documentation of this package.
+
+The settings for each visualization are documented on the [wiki](https://github.com/unipept/unipept-visualizations/wiki). The [`examples/`](examples) directory has a working page per visualization, and those are what the [live examples](https://unipept.github.io/unipept-visualizations/) are built from.
+
+## Development
+
+```sh
+npm install
+npm run build      # bundle and type declarations into dist/
+npm test           # unit tests plus visual regression tests in a real browser
+npm run lint
+npm run typecheck
+```
+
+`npm run dev` serves the repository so the pages in [`examples/`](examples) can be opened against your working copy; see [examples/README.md](examples/README.md).
+
+The visual regression tests screenshot the visualizations in Chromium and compare against `test/snapshots`. When a change is meant to alter what is drawn, delete the affected snapshot and let the next run record it, then check the new image before committing it.
+
+## Releasing
+
+Bump the version in `package.json`, commit, then push a matching tag:
+
+```sh
+git tag v2.2.6
+git push origin v2.2.6
+```
+
+That runs [`publish.yml`](.github/workflows/publish.yml), which reruns CI, checks the tag against `package.json`, publishes to npm with provenance and creates the GitHub release. A prerelease tag such as `v3.0.0-rc.1` is published under the `next` dist-tag instead of `latest`.
+
+## Citing
+
+If you use this library in published work, please cite [Unipept Visualizations: an interactive visualization library for biological data](https://doi.org/10.1093/bioinformatics/btab590) (*Bioinformatics*, 2021). [`CITATION.cff`](CITATION.cff) has the machine-readable version.
+
+## License
+
+[MIT](LICENSE.md)


### PR DESCRIPTION
Stacked on #185.

The README described a version of this package that hasn't existed for years. Line by line, what was wrong:

| Claim | Reality |
| --- | --- |
| "uses D3 (v6) internally" | `package.json` requires `d3: ^7.9.0`, and the examples load 7.9.0 |
| "Download and include `unipept-visualizations.min.js`" | The build has never produced a `.min.js`. The link next to it pointed at `unipept-visualizations.js` |
| "a treeview, a treemap, a sunburst graph and a heatmap are available" | There's a barplot too, and has been since 2.2.0 |
| No mention of npm | Which is how every consumer installs it — `unipept/unipept` depends on `^2.2.5` |
| "[D3.js] is required to use these visualizations" | **It isn't.** See below |
| "a transpiled ES6-compatible version ... is available in the `dist` directory" | `dist/` is no longer committed as of #182 |

## D3 is bundled

Worth calling out separately because it changes the install instructions. `vite.config.ts` sets no `rollupOptions.external`, so d3 is compiled into `dist/unipept-visualizations.js` — I confirmed it by reading the bundle: `function ts(t, r) { return t == null || r == null ? NaN : ... }` at the top is d3-array's `ascending`, name-mangled. Consumers get d3 whether they load it or not.

The examples do load d3 from a CDN, which is probably where the requirement in the README came from — but that's because the example code itself calls `d3.json()` to fetch its data, not because the library needs it.

One consequence I've left alone: `d3` is declared under `dependencies` *and* bundled, so npm consumers download it twice. Harmless, but if you'd rather it were externalized (smaller package, d3 deduped with the host app's copy) that's a real change to the build with real consequences for the CDN and script-tag paths, and belongs in its own PR.

## What's in it now

Install from npm; a snippet per data shape — hierarchical for treeview/treemap/sunburst, bars for the barplot, matrix plus labels for the heatmap; CDN usage via jsDelivr's `+esm` for people without a bundler; a development section; a release section documenting the tag flow from #184; and the citation.

**Every snippet was executed**, not eyeballed: I built the library, loaded all five constructors in Chromium with exactly the data shown, and checked each one both constructs and puts nodes in the DOM.

```
treeview: ok   treemap: ok   sunburst: ok   barplot: ok   heatmap: ok
nodes:    tv=16  tm=7  sb=13  bp=64  hm=1 (the canvas)
```

I also checked that jsDelivr actually serves this package as an ES module before documenting it — `https://cdn.jsdelivr.net/npm/unipept-visualizations@2.2.5/+esm` returns 200 and 322 kB.

## Two notes

- **The CI badge will 404 until #184 lands**, since it points at `ci.yml`. Same for the Pages link and #185.
- **The wiki has no Barplot page**, so I deliberately did not write "every setting is documented there". I'm looking at the wiki next — it was last touched in July 2021 and still says D3 v6 — and will report separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)