### PR TITLE
Fix the spacing that .wrap was silently eating

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -48,7 +48,10 @@
   }
   a { color: inherit; }
 
-  .wrap { margin: 0 auto; max-width: 70rem; padding: 0 1.5rem; }
+  /* Axis-specific only: `.wrap` also matches <main> and <footer> and
+     out-specifies them, so a `margin`/`padding` shorthand here would silently
+     drop whatever block-axis spacing those elements set for themselves. */
+  .wrap { margin-inline: auto; max-width: 70rem; padding-inline: 1.5rem; }
 
   /* ---------- hero ---------- */
   header {
@@ -78,6 +81,8 @@
     border-radius: .5rem;
     font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: .9rem;
+    max-width: 100%;
+    overflow-x: auto;
     padding: .6rem .9rem;
     white-space: nowrap;
   }
@@ -100,19 +105,30 @@
   .btn-primary:hover { background: var(--accent); border-color: var(--accent); filter: brightness(1.1); }
 
   /* ---------- gallery ---------- */
-  main { padding: 3.5rem 0 1rem; }
+  main { padding-block: 4rem 1rem; }
   .section-label {
+    align-items: baseline;
     color: var(--text-dim);
-    font-size: .8rem;
+    display: flex;
+    font-size: .78rem;
     font-weight: 500;
-    letter-spacing: .08em;
-    margin: 0 0 1.5rem;
+    gap: 1rem;
+    letter-spacing: .09em;
+    margin: 0 0 1.75rem;
     text-transform: uppercase;
+  }
+  .section-label::after {
+    background: var(--border);
+    content: "";
+    flex: 1 1 1.5rem;
+    height: 1px;
+    min-width: 1.5rem;
   }
   .grid {
     display: grid;
     gap: 1.75rem;
-    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    /* min() so a 20rem track cannot outgrow a narrower viewport. */
+    grid-template-columns: repeat(auto-fill, minmax(min(20rem, 100%), 1fr));
     margin: 0;
     padding: 0;
   }
@@ -173,12 +189,12 @@
   .card-foot { align-items: center; display: flex; flex-wrap: wrap; gap: .5rem; margin-top: auto; padding-top: .5rem; }
 
   /* ---------- footer ---------- */
-  footer.wrap {
+  footer {
     border-top: 1px solid var(--border);
     color: var(--text-dim);
     font-size: .88rem;
     margin-top: 4rem;
-    padding: 2.5rem 1.5rem 3.5rem;
+    padding-block: 2.5rem 3.5rem;
   }
   footer p { margin: 0 0 .6rem; }
   footer a { color: var(--accent); text-decoration: none; }
@@ -205,7 +221,7 @@
 </header>
 
 <main class="wrap">
-  <p class="section-label">Live examples &mdash; every page below runs the real library</p>
+  <p class="section-label">Live examples</p>
   <ul class="grid">
 
     <li class="card">


### PR DESCRIPTION
You were right, and the cause is more interesting than a missing padding value — it's the same bug I found in #192 and then only half-fixed.

```css
.wrap { padding: 0 1.5rem; }        /* specificity 0-1-0 */
main  { padding: 3.5rem 0 1rem; }   /* specificity 0-0-1 — loses */
```

`.wrap` also matches `<main>` and `<footer>`, and both sides used the `padding` **shorthand**, so `.wrap` overrode the entire declaration and `main` had *no vertical padding at all*. Its rule sat there in the stylesheet looking perfectly correct. The heading was 21px below the hero border instead of 56.

Worse: in #192 I "fixed" the footer by changing it to `footer.wrap` — patching the instance instead of the class of bug. That promptly reintroduced it on the **margin** axis, because `.wrap`'s `margin: 0 auto` outranks `footer { margin-top: 4rem }` in exactly the same way. The gap under the last card had quietly collapsed from 64px to 16px.

**The actual fix:** `.wrap` now sets only `margin-inline` and `padding-inline`. Different properties from the block-axis ones, so they cannot collide regardless of specificity, and `main`/`footer` can own their own vertical rhythm. Measured: header→heading 64px, last card→footer 80px, consistent at every width tested.

The heading also gets a hairline rule trailing off to the right, so it reads as a section divider rather than floating grey text.

## Two responsive bugs found while measuring

Both were already in the page I added in #192:

- **`minmax(20rem, 1fr)` forces a 320px track even in a 320px viewport**, so the cards pushed the page 24px wide. `minmax(min(20rem, 100%), 1fr)` fixes it.
- **The `npm install` snippet is `white-space: nowrap`** and overflowed below 360px. It scrolls within itself now rather than pushing the page.

## Verified

Assembled the site the way `pages.yml` does, then measured at **320, 360, 420, 480, 600, 700, 900, 1100 and 1400px**:

```
@1400: overflow=0px cols=3 hdr->label=64 card->footer=80
@1100: overflow=0px cols=3 hdr->label=64 card->footer=80
@ 900: overflow=0px cols=2 hdr->label=64 card->footer=80
@ 700: overflow=0px cols=1 hdr->label=64 card->footer=80
@ 600: overflow=0px cols=1 hdr->label=64 card->footer=80
@ 480: overflow=0px cols=1 hdr->label=64 card->footer=80
@ 420: overflow=0px cols=1 hdr->label=64 card->footer=80
@ 360: overflow=0px cols=1 hdr->label=64 card->footer=80
@ 320: overflow=0px cols=1 hdr->label=64 card->footer=80
```

No horizontal overflow anywhere, no page errors, and the grid steps 3 → 2 → 1 column cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)