### PR TITLE
Check ancestry by walking up instead of searching down

### DIFF
--- a/src/utilities/NodeUtils.ts
+++ b/src/utilities/NodeUtils.ts
@@ -19,14 +19,12 @@ export default class NodeUtils {
             return false;
         }
 
-        if (p === c) {
-            return true;
-        }
-
-        if (p.children) {
-            return p.children.some((d: d3.HierarchyRectangularNode<DataNode>) => {
-                return NodeUtils.isParentOf(d, c, maxLevels);
-            });
+        let current: d3.HierarchyRectangularNode<DataNode> | null = c;
+        while (current) {
+            if (current === p) {
+                return true;
+            }
+            current = current.parent;
         }
 
         return false;

--- a/src/utilities/__tests__/NodeUtils.spec.ts
+++ b/src/utilities/__tests__/NodeUtils.spec.ts
@@ -1,7 +1,18 @@
 import NodeUtils from "./../NodeUtils";
 
+/**
+ * Links every node to its parent, the way d3.hierarchy() does. isParentOf walks
+ * up from the child, so a fixture without these pointers only exercises the
+ * depth guard.
+ */
+function linkParents(node: any, parent: any = null): any {
+    node.parent = parent;
+    (node.children ?? []).forEach((child: any) => linkParents(child, node));
+    return node;
+}
+
 describe("NodeUtils.isParentOf", () => {
-    const hierarchy = {
+    const hierarchy = linkParents({
         id: 1,
         depth: 0,
         children: [
@@ -33,21 +44,46 @@ describe("NodeUtils.isParentOf", () => {
                 children: []
             }
         ]
-    }
+    });
 
     it("should correctly detect proper parents", () => {
         const parent = hierarchy;
         const child = hierarchy.children[0].children[1].children[0];
 
-        // @ts-expect-error
         expect(NodeUtils.isParentOf(parent, child, 4)).toBeTruthy();
+    });
+
+    it("should correctly detect intermediate parents", () => {
+        const parent = hierarchy.children[0].children[1];
+        const child = parent.children[0];
+
+        expect(NodeUtils.isParentOf(parent, child, 4)).toBeTruthy();
+    });
+
+    it("should consider a node its own parent", () => {
+        const node = hierarchy.children[0];
+
+        expect(NodeUtils.isParentOf(node, node, 4)).toBeTruthy();
+    });
+
+    it("should not treat a child as the parent of its own parent", () => {
+        const parent = hierarchy.children[0];
+        const child = parent.children[0];
+
+        expect(NodeUtils.isParentOf(child, parent, 4)).toBeFalsy();
+    });
+
+    it("should return false for nodes in a different branch", () => {
+        const parent = hierarchy.children[0];
+        const other = hierarchy.children[1];
+
+        expect(NodeUtils.isParentOf(parent, other, 4)).toBeFalsy();
     });
 
     it("should correctly refuse child nodes that are too deep", () => {
         const parent = hierarchy;
         const child = hierarchy.children[0].children[1].children[0];
 
-        // @ts-expect-error
         expect(NodeUtils.isParentOf(parent, child, 3)).toBeFalsy();
     });
 
@@ -56,7 +92,8 @@ describe("NodeUtils.isParentOf", () => {
         const child = {
             id: 7,
             depth: 3,
-            children: []
+            children: [],
+            parent: null
         };
 
         // @ts-expect-error


### PR DESCRIPTION
This is the good idea buried in draft PRs #175 and #178, reimplemented cleanly. **810 ms → 1.9 ms.**

`NodeUtils.isParentOf` answered *"is `p` an ancestor of `c`"* by recursing **down** through every descendant of `p` looking for `c` — O(size of `p`'s subtree). The sunburst calls it from inside three separate filters over every node (`Sunburst.ts` 325, 383, 459), so a render cost node-count × subtree-size.

d3 hierarchy nodes already carry a `parent` pointer, so the same question answers by walking **up** from `c` — O(depth). **Nothing is cached and no new state is introduced**, so there is nothing to invalidate and nothing that can go stale; d3 maintains the pointers itself, including across a re-root.

## Measured, not asserted

On a 3280-node tree of depth 7, filtering every node against the root — the shape the sunburst actually uses:

```
descending:  809.6 ms for 20 full filters
ascending:     1.9 ms for 20 full filters
```

And for equivalence, both implementations over every `(p, c, maxLevels)` combination from a sampled cross-product:

```
1,099,805 combinations, 0 mismatches
```

## The test fixture was only ever half-testing this

`NodeUtils.spec.ts` builds its hierarchy as a nested literal with **no `parent` pointers**. Under the old downward implementation that was fine. Under an upward walk it means `isParentOf` can never find anything, so the suite went red the moment I made the change — the fixture had been exercising the depth guard and little else.

It now gets its pointers linked the way `d3.hierarchy()` does, and gains four cases the old fixture could not express at all:

| test | why it matters |
| --- | --- |
| an intermediate parent, not just the root | the recursion's base case wasn't the only path |
| a node against itself | the old code had an explicit `p === c` branch; the loop's first iteration preserves it |
| the relation **in reverse** | nothing asserted that `isParentOf(child, parent)` is false |
| a node in a sibling branch | distinguishes "not an ancestor" from "too deep" |

3 tests → 7, and all 7 pass.

## On #175 and #178

Both propose a **byte-identical** change to `NodeUtils.ts` — the same upward walk. They differ only in how they patch the test, and both also commit a `.jules/bolt.md` agent scratch file that doesn't belong in the repo.

For the record, #175 has the better of the two test adaptations: it keeps the readable nested literal and adds a helper to link parents, where #178 flattens the fixture into eleven separate `const` declarations and loses the visual tree shape. I've taken #175's approach and gone further on coverage. Both can be closed.

## Verified

`npm run lint`, `npm run typecheck` and `npm run build` clean; `npm test` 33 pass (up from 29 — the 4 new NodeUtils cases), with the same 4 heatmap failures I get on `main` from `canvas`'s native module not building in my sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)