### PR TITLE
Memoize the sunburst's interior node colours

### DIFF
--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -18,6 +18,15 @@ export default class Sunburst {
     private breadCrumbs: d3.Selection<HTMLUListElement, unknown, HTMLElement, any>;
 
     private colorCounter: number = -1;
+
+    /**
+     * Colour of each interior node, which is a pure function of the colours of
+     * its children and therefore stable for the lifetime of this Sunburst: the
+     * data is preprocessed once, in the constructor, so no node's children ever
+     * change. Keyed on the node itself rather than stored on `extra`, so that a
+     * second Sunburst over the same input data does not inherit these.
+     */
+    private readonly computedColors: Map<DataNode, string | d3.HSLColor> = new Map();
     private currentMaxLevel: number = 4;
 
     private xScale: d3.ScaleLinear<number, number>;
@@ -138,7 +147,21 @@ export default class Sunburst {
      * @param d The node for which we want the color.
      * @return string The calculated color in HTML color representation.
      */
-    private color(d: DataNode) {
+    private static toHsl(colour: string | d3.HSLColor): d3.HSLColor {
+        return typeof colour === "string" ? d3.hsl(colour) : d3.hsl(colour);
+    }
+
+    /**
+     * The colour to paint a node with, as a string the DOM can take directly.
+     * `color` keeps returning d3 colour objects for interior nodes because the
+     * recursion averages them, and going through a string at every level would
+     * round trip each average through 8-bit rgb.
+     */
+    private fillColor(d: DataNode): string {
+        return String(this.color(d));
+    }
+
+    private color(d: DataNode): string | d3.HSLColor {
         if (d.name === "empty") {
             return "white";
         }
@@ -148,18 +171,27 @@ export default class Sunburst {
             ];
         } else {
             if (d.children.length > 0) {
-                const colours: string[] = d.children.map(c => this.color(c));
-                const a = d3.hsl(colours[0]);
-                const b = d3.hsl(colours[1]);
-                const singleChild = d.children.length === 1 || d.children[1].name === "empty";
-
-                // if we only have one child, return a slightly darker variant of the child color
-                if (singleChild) {
-                    return d3.hsl(a.h, a.s, a.l * 0.98);
+                const memoized = this.computedColors.get(d);
+                if (memoized !== undefined) {
+                    return memoized;
                 }
 
-                // if we have 2 children or more, take the average of the first two children
-                return d3.hsl((a.h + b.h) / 2, (a.s + b.s) / 2, (a.l + b.l) / 2);
+                // Every child is visited, not only the two whose colour is used:
+                // colouring a leaf advances the palette counter, so skipping a
+                // child would change the colour of every leaf after it.
+                const colours: (string | d3.HSLColor)[] = d.children.map(c => this.color(c));
+                const a = Sunburst.toHsl(colours[0]);
+                const b = Sunburst.toHsl(colours[1]);
+                const singleChild = d.children.length === 1 || d.children[1].name === "empty";
+
+                const colour = singleChild
+                    // if we only have one child, return a slightly darker variant of the child color
+                    ? d3.hsl(a.h, a.s, a.l * 0.98)
+                    // if we have 2 children or more, take the average of the first two children
+                    : d3.hsl((a.h + b.h) / 2, (a.s + b.s) / 2, (a.l + b.l) / 2);
+
+                this.computedColors.set(d, colour);
+                return colour;
             }
             // if we don't have children, pick a new color
             if (!d.extra.color) {
@@ -342,7 +374,7 @@ export default class Sunburst {
             .attr("id", (d: HRN<DataNode>, i: number) => "path-" + i) // id based on index
             .attr("d", this.arc) // path data
             .attr("fill-rule", "evenodd") // fill rule
-            .style("fill", (d: HRN<DataNode>) => this.color(d.data)) // call function for colour
+            .style("fill", (d: HRN<DataNode>) => this.fillColor(d.data)) // call function for colour
             .attr("fill-opacity", d => d.depth >= this.previousMaxLevel ? 0.2 : 1)
             .on("click", (event: MouseEvent, d: HRN<DataNode>) => {
                 if (d.depth < this.currentMaxLevel) {
@@ -410,7 +442,7 @@ export default class Sunburst {
 
         // Add new text nodes
         this.text = this.visGElement.selectAll("text").data(data).enter().append("text")
-            .style("fill", (d: HRN<DataNode>) => ColorUtils.getReadableColorFor(this.color(d.data)))
+            .style("fill", (d: HRN<DataNode>) => ColorUtils.getReadableColorFor(this.fillColor(d.data)))
             .style("fill-opacity", 0)
             .style("font-family", "font-family: Helvetica, 'Super Sans', sans-serif")
             .style("pointer-events", "none") // don't invoke mouse events
@@ -504,7 +536,7 @@ export default class Sunburst {
             .append("path")
             .attr("d", breadArc)
             .attr("transform", "translate(15, 15)")
-            .attr("fill", (d: HRN<DataNode>) => this.color(d.data));
+            .attr("fill", (d: HRN<DataNode>) => this.fillColor(d.data));
 
         this.breadCrumbs.selectAll(".crumb")
             .transition()

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -20,13 +20,13 @@ export default class Sunburst {
     private colorCounter: number = -1;
 
     /**
-     * Colour of each interior node, which is a pure function of the colours of
+     * Colour of each blended node, which is a pure function of the colours of
      * its children and therefore stable for the lifetime of this Sunburst: the
      * data is preprocessed once, in the constructor, so no node's children ever
      * change. Keyed on the node itself rather than stored on `extra`, so that a
      * second Sunburst over the same input data does not inherit these.
      */
-    private readonly computedColors: Map<DataNode, string | d3.HSLColor> = new Map();
+    private readonly blendedColors: Map<DataNode, d3.HSLColor> = new Map();
     private currentMaxLevel: number = 4;
 
     private xScale: d3.ScaleLinear<number, number>;
@@ -142,63 +142,78 @@ export default class Sunburst {
     }
 
     /**
+     * Whether the colour of a node is the average of the colours of its
+     * children, rather than one taken straight from a palette.
+     */
+    private isBlended(d: DataNode): boolean {
+        return d.name !== "empty" && !this.settings.useFixedColors && d.children.length > 0;
+    }
+
+    /**
+     * The colour a node takes directly from a palette, in the HTML colour
+     * representation that palette uses.
+     *
+     * @param d A node that is not blended, i.e. `isBlended(d)` is false.
+     */
+    private unblendedColor(d: DataNode): string {
+        if (d.name === "empty") {
+            return "white";
+        }
+
+        if (this.settings.useFixedColors) {
+            return this.settings.fixedColorPalette[
+                Math.abs(this.settings.fixedColorHash(d)) % this.settings.fixedColorPalette.length
+            ];
+        }
+
+        // A leaf: pick the next colour off the palette, once.
+        if (!d.extra.color) {
+            d.extra.color = this.getColor();
+        }
+        return d.extra.color;
+    }
+
+    /**
+     * The colour of an arc, averaged from the colours of its first two
+     * children. Stays an HSL object rather than a string because each level
+     * averages the level below it, and going through a string in between would
+     * round trip every average through 8-bit rgb and shift the result.
+     *
+     * @param d A node that is blended, i.e. `isBlended(d)` is true.
+     */
+    private blendedColor(d: DataNode): d3.HSLColor {
+        const memoized = this.blendedColors.get(d);
+        if (memoized !== undefined) {
+            return memoized;
+        }
+
+        // Every child is visited, not only the two whose colour is used:
+        // colouring a leaf advances the palette counter, so skipping a child
+        // would change the colour of every leaf after it.
+        const colours = d.children.map(
+            c => this.isBlended(c) ? this.blendedColor(c) : d3.hsl(this.unblendedColor(c))
+        );
+        const [a, b] = colours;
+        const singleChild = d.children.length === 1 || d.children[1].name === "empty";
+
+        const colour = singleChild
+            // if we only have one child, return a slightly darker variant of the child color
+            ? d3.hsl(a.h, a.s, a.l * 0.98)
+            // if we have 2 children or more, take the average of the first two children
+            : d3.hsl((a.h + b.h) / 2, (a.s + b.s) / 2, (a.l + b.l) / 2);
+
+        this.blendedColors.set(d, colour);
+        return colour;
+    }
+
+    /**
      * Calculates the color of an arc based on the color of his children.
      *
      * @param d The node for which we want the color.
      * @return string The calculated color in HTML color representation.
      */
-    private static toHsl(colour: string | d3.HSLColor): d3.HSLColor {
-        return typeof colour === "string" ? d3.hsl(colour) : d3.hsl(colour);
-    }
-
-    /**
-     * The colour to paint a node with, as a string the DOM can take directly.
-     * `color` keeps returning d3 colour objects for interior nodes because the
-     * recursion averages them, and going through a string at every level would
-     * round trip each average through 8-bit rgb.
-     */
-    private fillColor(d: DataNode): string {
-        return String(this.color(d));
-    }
-
-    private color(d: DataNode): string | d3.HSLColor {
-        if (d.name === "empty") {
-            return "white";
-        }
-        if (this.settings.useFixedColors) {
-            return this.settings.fixedColorPalette[
-                Math.abs(this.settings.fixedColorHash(d)) % this.settings.fixedColorPalette.length
-            ];
-        } else {
-            if (d.children.length > 0) {
-                const memoized = this.computedColors.get(d);
-                if (memoized !== undefined) {
-                    return memoized;
-                }
-
-                // Every child is visited, not only the two whose colour is used:
-                // colouring a leaf advances the palette counter, so skipping a
-                // child would change the colour of every leaf after it.
-                const colours: (string | d3.HSLColor)[] = d.children.map(c => this.color(c));
-                const a = Sunburst.toHsl(colours[0]);
-                const b = Sunburst.toHsl(colours[1]);
-                const singleChild = d.children.length === 1 || d.children[1].name === "empty";
-
-                const colour = singleChild
-                    // if we only have one child, return a slightly darker variant of the child color
-                    ? d3.hsl(a.h, a.s, a.l * 0.98)
-                    // if we have 2 children or more, take the average of the first two children
-                    : d3.hsl((a.h + b.h) / 2, (a.s + b.s) / 2, (a.l + b.l) / 2);
-
-                this.computedColors.set(d, colour);
-                return colour;
-            }
-            // if we don't have children, pick a new color
-            if (!d.extra.color) {
-                d.extra.color = this.getColor();
-            }
-            return d.extra.color;
-        }
+    private color(d: DataNode): string {
+        return this.isBlended(d) ? this.blendedColor(d).toString() : this.unblendedColor(d);
     }
 
     /**
@@ -374,7 +389,7 @@ export default class Sunburst {
             .attr("id", (d: HRN<DataNode>, i: number) => "path-" + i) // id based on index
             .attr("d", this.arc) // path data
             .attr("fill-rule", "evenodd") // fill rule
-            .style("fill", (d: HRN<DataNode>) => this.fillColor(d.data)) // call function for colour
+            .style("fill", (d: HRN<DataNode>) => this.color(d.data)) // call function for colour
             .attr("fill-opacity", d => d.depth >= this.previousMaxLevel ? 0.2 : 1)
             .on("click", (event: MouseEvent, d: HRN<DataNode>) => {
                 if (d.depth < this.currentMaxLevel) {
@@ -442,7 +457,7 @@ export default class Sunburst {
 
         // Add new text nodes
         this.text = this.visGElement.selectAll("text").data(data).enter().append("text")
-            .style("fill", (d: HRN<DataNode>) => ColorUtils.getReadableColorFor(this.fillColor(d.data)))
+            .style("fill", (d: HRN<DataNode>) => ColorUtils.getReadableColorFor(this.color(d.data)))
             .style("fill-opacity", 0)
             .style("font-family", "font-family: Helvetica, 'Super Sans', sans-serif")
             .style("pointer-events", "none") // don't invoke mouse events
@@ -536,7 +551,7 @@ export default class Sunburst {
             .append("path")
             .attr("d", breadArc)
             .attr("transform", "translate(15, 15)")
-            .attr("fill", (d: HRN<DataNode>) => this.fillColor(d.data));
+            .attr("fill", (d: HRN<DataNode>) => this.color(d.data));
 
         this.breadCrumbs.selectAll(".crumb")
             .transition()


### PR DESCRIPTION
`Sunburst.color()` computes a node's colour by recursing over its children, so answering it for one node costs its entire subtree — and it's called once per node from **three** separate `.style("fill")` passes. A render is quadratic in the tree.

That colour is a pure function of the children's colours, and the data is preprocessed exactly once, in the constructor (`Sunburst.ts:45`), so no node's children ever change for the lifetime of a Sunburst. So it's cacheable.

Timing the DOM-ready string for every node, 200 passes:

| nodes | before | after | |
| ---: | ---: | ---: | ---: |
| 364 | 46.9 ms | 6.6 ms | 7.1× |
| 1093 | 106.6 ms | 12.3 ms | 8.7× |
| 3280 | 366.4 ms | 38.0 ms | 9.6× |

Modest next to #194's 430×, and it grows with depth rather than node count.

## A node's colour has two sources, and that is the seam

Either it comes straight out of a palette, or it is averaged from its children. Which one applies is a property of the *node*, so that is where the branch belongs:

```ts
private isBlended(d: DataNode): boolean          // does this node average its children?
private unblendedColor(d: DataNode): string      // "empty" / fixed palette / next palette colour
private blendedColor(d: DataNode): d3.HSLColor   // recurses, memoized, stays in HSL

private color(d: DataNode): string {
    return this.isBlended(d) ? this.blendedColor(d).toString() : this.unblendedColor(d);
}
```

Each function has a single return type, `color()` still hands the render sites a string, and only `blendedColor` is memoized — because only it is expensive.

## Two things this deliberately does *not* do — both of which #177 got wrong

**It does not skip the children whose colour is never read.** The average only ever looks at `colours[0]` and `colours[1]`, so mapping over *every* child looks like obvious waste. It isn't: colouring a leaf calls `getColor()`, which advances `this.colorCounter`. Visiting fewer children changes which colour every later leaf gets. This was the trap worth checking before touching anything.

**It does not put a string in the cache.** #177 caches `result.toString()`, and that silently changes the rendered colours:

```
d3.hsl(200.5, 0.55, 0.42)          -> h=200.5,              s=0.55
  .toString() -> "rgb(48, 126, 166)"
  -> d3.hsl(...)                   -> h=200.33898305084745, s=0.5514018691588786
```

Since every level averages the level below it, that 8-bit round trip compounds up the tree. Averages stay as `d3.HSLColor` for the whole recursion and become a string exactly once, at the DOM boundary. Palette colours never enter HSL at all, so a leaf's `#b9763f` reaches the DOM as `#b9763f`.

(#177 also returns a `d3.HSLColor` on a cache miss and a `string` on a hit — the same function handing back two different types depending on call order.)

## The cache does not leak between instances

It's a `Map` keyed on the node and owned by the Sunburst, not a property written onto `d.extra`. #177 writes to `extra`, which the preprocessor passes straight through from the caller's data (`SunburstPreprocessor.ts:31`) — so two sunbursts built from the same input object would share it. `sunburst-multi.html` does exactly that.

## Verified byte for byte

`main` and this branch built into separate trees and probed side by side: every fill value on all three sunburst example pages, in the initial state **and after re-rooting**, including the page that renders several sunbursts from shared data.

```
sunburst-taxonomy.html             arcs= 102 texts= 32
sunburst-taxonomy.html#rerooted    arcs= 103 texts= 31
sunburst-flare.html                arcs= 284 texts=245
sunburst-flare.html#rerooted       arcs= 285 texts=244
sunburst-multi.html                arcs= 408 texts=299
sunburst-multi.html#rerooted       arcs= 409 texts=298

2740 fill values compared, 0 differences
```

The sunburst visual regression snapshots pass unchanged, as do lint, typecheck and build. (The 4 heatmap test failures are local `getContext`-under-jsdom ones that also fail on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
