### PR TITLE
Move to TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "pixelmatch": "^7.2.0",
                 "pngjs": "^7.0.0",
                 "puppeteer": "^25.8.0",
-                "typescript": "^5.9.3",
+                "typescript": "npm:@typescript/typescript6@^6.0.2",
                 "vite": "^8.2.1",
                 "vite-plugin-dts": "^5.0.3",
                 "vitest": "^4.1.11"
@@ -1169,6 +1169,189 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.67.0",
+                "@typescript-eslint/types": "^8.67.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.67.0",
+                "@typescript-eslint/types": "^8.67.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
         "node_modules/@typescript-eslint/parser": {
             "version": "8.67.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
@@ -1194,7 +1377,35 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/project-service": {
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
             "version": "8.67.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
             "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
@@ -1205,6 +1416,23 @@
                 "@typescript-eslint/types": "^8.67.0",
                 "debug": "^4.4.3"
             },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -1234,48 +1462,6 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
-            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
-            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/typescript-estree": "8.67.0",
-                "@typescript-eslint/utils": "8.67.0",
-                "debug": "^4.4.3",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
         "node_modules/@typescript-eslint/types": {
             "version": "8.67.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
@@ -1288,58 +1474,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
-            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.67.0",
-                "@typescript-eslint/tsconfig-utils": "8.67.0",
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/visitor-keys": "8.67.0",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
-            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.67.0",
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/typescript-estree": "8.67.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
@@ -1371,6 +1505,21 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript/old": {
+            "name": "typescript",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@vitest/expect": {
@@ -4405,17 +4554,17 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "name": "@typescript/typescript6",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+            "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
             "dev": true,
             "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
+            "dependencies": {
+                "@typescript/old": "npm:typescript@^6"
             },
-            "engines": {
-                "node": ">=14.17"
+            "bin": {
+                "tsc6": "bin/tsc6"
             }
         },
         "node_modules/ufo": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "test": "vitest run",
         "test:ui": "vitest --ui",
         "lint": "eslint \"src/**/*.ts\"",
-        "typecheck": "tsc --noEmit",
+        "typecheck": "tsc6 --noEmit",
         "build": "vite build",
         "prepack": "npm run build",
         "dev": "vite",
@@ -49,9 +49,12 @@
         "pixelmatch": "^7.2.0",
         "pngjs": "^7.0.0",
         "puppeteer": "^25.8.0",
-        "typescript": "^5.9.3",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
         "vite": "^8.2.1",
         "vite-plugin-dts": "^5.0.3",
         "vitest": "^4.1.11"
+    },
+    "allowScripts": {
+        "canvas": true
     }
 }

--- a/src/visualizations/treeview/Treeview.ts
+++ b/src/visualizations/treeview/Treeview.ts
@@ -275,6 +275,14 @@ export default class Treeview {
 
         const linkGenerator = d3.linkHorizontal<any, HPL<TreeviewNode>, HPN<TreeviewNode>>().x(d => d.y).y(d => d.x);
 
+        // The collapse animations draw a link that starts and ends in the same
+        // spot, so it has no hierarchy behind it. The generator only reads x and
+        // y, so a bare point stands in for the node it never looks at.
+        const collapsedLinkAt = (x: number, y: number) => {
+            const point = { x, y } as unknown as HPN<TreeviewNode>;
+            return linkGenerator({ source: point, target: point });
+        };
+
         // Enter any new links at the parent's previous position.
         link.enter()
             .insert("path", "g")
@@ -284,18 +292,10 @@ export default class Treeview {
             .style("stroke-linecap", "round")
             .style("stroke", (d: HPL<TreeviewNode>) => this.settings.linkStrokeColor(d))
             .style("stroke-width", 1e-6)
-            .attr("d", (_d: HPL<TreeviewNode>) => {
-                const o = {
-                    x: source.data.previousPosition.x,
-                    y: source.data.previousPosition.y
-                }
-
-                // @ts-expect-error
-                return linkGenerator({
-                    source: o,
-                    target: o
-                });
-            })
+            .attr("d", () => collapsedLinkAt(
+                source.data.previousPosition.x,
+                source.data.previousPosition.y
+            ))
             .merge(link)
             .transition()
             .duration(this.settings.animationDuration)
@@ -313,19 +313,7 @@ export default class Treeview {
         link.exit().transition()
             .duration(this.settings.animationDuration)
             .style("stroke-width", 1e-6)
-            // @ts-expect-error
-            .attr("d", (_d: HPL<TreeviewNode>) => {
-                const o = {
-                    x: source.x,
-                    y: source.y
-                };
-
-                // @ts-expect-error
-                return linkGenerator({
-                    source: o,
-                    target: o
-                });
-            })
+            .attr("d", () => collapsedLinkAt(source.x, source.y))
             .remove();
 
         // Keep track of the old positions for the transitions

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,9 @@ import dts from 'vite-plugin-dts';
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: resolve(import.meta.dirname, 'src/index.ts'),
       name: 'UnipeptVisualizations',
-      fileName: (format) => `unipept-visualizations.js`,
+      fileName: () => 'unipept-visualizations.js',
       formats: ['es'],
     },
     sourcemap: true,


### PR DESCRIPTION
> Stacked on #196 — merge that one first.

TypeScript was the only outdated dependency in the repo. `npm outdated` had exactly one row, and it is empty after this.

The naming is confusing, so to be explicit: the `typescript` package's `latest` is now **7.0.2**, the native Go port. TypeScript 6.0 ships as a **separate package**, `@typescript/typescript6@6.0.2`, whose binary is `tsc6` so it can sit next to TS 7's `tsc`. That is why the `typecheck` script changes.

```json
"typescript": "npm:@typescript/typescript6@^6.0.2"
```

The alias is needed rather than a plain `@typescript/typescript6` dependency, because typescript-eslint and vite-plugin-dts both resolve the compiler as `typescript`.

## Why 6 and not 7

typescript-eslint refuses to load against TS 7 — the process exits rather than warning:

```
Error: typescript-eslint does not support TS 7.0
```

Tracked in typescript-eslint#10940, targeting TS >= 7.1. Since `ci.yml` runs `npm run lint`, TS 7 would fail the build today. When typescript-eslint ships support, this becomes a one-line version bump.

A side-by-side layout (`typescript` → TS 6 for eslint and vite-plugin-dts, an alias → TS 7 for `tsc`) does work, and I had it green. It saves 0.5s on this repo's typecheck (1.26s → 0.73s) and costs Dependabot, which does not bump npm aliases. Not worth it at this size.

## Two `@ts-expect-error` directives in Treeview.ts

Both collapse animations draw a link whose source and target are the same point. That object is not a `HierarchyPointLink`, so the call was suppressed. TS 7 attributes the error to the argument lines rather than the call line, which would leave the directives dead *and* the errors live.

Moving the comments would work, but a suppression whose correctness depends on which line a given compiler blames is not worth keeping. The point gets a name instead:

```ts
// The collapse animations draw a link that starts and ends in the same
// spot, so it has no hierarchy behind it. The generator only reads x and
// y, so a bare point stands in for the node it never looks at.
const collapsedLinkAt = (x: number, y: number) => {
    const point = { x, y } as unknown as HPN<TreeviewNode>;
    return linkGenerator({ source: point, target: point });
};
```

One cast, the reason written down, no suppression on either compiler, and the two duplicated blocks collapse into two call sites. A third directive above the exit transition became unnecessary and is gone.

This is the only bundle change; I diffed a TS 5 build of `main` against this one to confirm nothing else moved.

## Two fixes that were in the way

**`npm ci` leaves canvas unbuilt.** npm 12 blocks install scripts by default, so `canvas` never compiles its native binary and four Heatmap tests fail on a null 2D context, which looks like a real regression. CI happens to survive this today, but a clean `npm ci` locally does not. `allowScripts` declares it, by bare name so it survives the next `canvas` bump:

```json
"allowScripts": { "canvas": true }
```

Verified both ways: with the binary removed, `vitest run src/visualizations/heatmap` fails 4 of 9; with this change a clean install builds it and the full suite passes 37/37.

**`vite.config.ts` used `__dirname`**, which Vite 8 warns about on every build. Now `import.meta.dirname`. Also dropped an unused `format` parameter and its interpolation-free template literal.

## Checks

`typecheck` ✓ · `lint` ✓ · `build` ✓ (warning-free) · 37/37 tests ✓ · `npm audit` 0 vulnerabilities · `npm outdated` empty
