### PR TITLE
Style the example pages and explain what each one shows

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,3 +31,17 @@ the same server.
 | `barplot-taxonomy.html` | A stacked barplot |
 | `heatmap-random.html` | Randomly generated values |
 | `heatmap-clusters.html` | A CSV of pre-clustered values |
+
+## How a page is put together
+
+`index.html` is the gallery; every other page is one example. They share two
+files and have no styles or scripts of their own:
+
+- `examples.css` — the whole theme, for the gallery and the example pages
+  alike. It is the only place colours, spacing and dark mode are defined.
+- `examples.js` — prints each example's own module script into its "Source"
+  block, so the code on the page is by construction the code that ran.
+
+An example page is therefore its `<h1>`, a paragraph on what it shows and which
+settings it passes, a `<figure class="stage">` for the visualization to render
+into, and the module script that builds it.

--- a/examples/barplot-taxonomy.html
+++ b/examples/barplot-taxonomy.html
@@ -1,25 +1,53 @@
-<html>
-    <head>
-        <title>Barplot example</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Stacked barplot of two samples &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    </head>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Barplot &middot; Taxonomy</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Barplot">Docs &rarr;</a></span>
+  </div>
+</header>
 
-    <body>
-        <div id="d3Barplot"></div>
+<main class="wrap example">
+  <h1>Stacked barplot of two samples</h1>
+  <p class="lede">Two samples as stacked bars, with the categories aligned and coloured the same way in both so the
+    bars can be read against each other. This page passes no settings at all, so everything you see
+    &mdash; size, colours, legend, tooltips &mdash; is the barplot's default.</p>
 
-        <script type="module">
-            import { Barplot, BarplotSettings } from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Barplot"></div></figure>
 
-            d3.json("data/bars.json").then(data => {
-                new Barplot(
-                    document.getElementById("d3Barplot"),
-                    data
-                );
-            });
-        </script>
-    </body>
+<script type="module" data-source>
+    import { Barplot } from "../dist/unipept-visualizations.js";
+
+    d3.json("data/bars.json").then(data => {
+        new Barplot(
+            document.getElementById("d3Barplot"),
+            data
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -1,0 +1,314 @@
+/*
+ * Shared styling for the example gallery and the individual example pages.
+ *
+ * Loaded by index.html and by every *.html example next to it. The pages carry
+ * no styles of their own, so this is the only place the theme is defined.
+ */
+
+:root {
+    /* `light dark` keeps the browser's own surfaces — scrollbars, form
+       controls, the canvas behind the page — following the system setting.
+       Every token below is a light-dark() pair, so nothing needs a media
+       query to switch with it. */
+    color-scheme: light dark;
+    accent-color: var(--accent);
+
+    --bg: light-dark(#ffffff, #101014);
+    --bg-raised: light-dark(#f7f7f9, #18181e);
+    --bg-sunken: light-dark(#eeeef2, #0b0b0e);
+    --text: light-dark(#16161a, #f2f2f5);
+    --text-dim: light-dark(#5b5b66, #a0a0ae);
+    --border: light-dark(#dcdce4, #2a2a34);
+    --accent: light-dark(#a0248c, #f472d0);
+    --accent-text: light-dark(#ffffff, #1a0417);
+
+    --shadow:
+        0 1px 2px light-dark(rgba(20, 20, 30, .06), rgba(0, 0, 0, .4)),
+        0 8px 24px light-dark(rgba(20, 20, 30, .06), rgba(0, 0, 0, .3));
+    --shadow-hover:
+        0 2px 4px light-dark(rgba(20, 20, 30, .08), rgba(0, 0, 0, .5)),
+        0 16px 40px light-dark(rgba(20, 20, 30, .12), rgba(0, 0, 0, .45));
+
+    --font: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --font-mono: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font);
+    line-height: 1.6;
+    margin: 0;
+}
+
+a { color: inherit; }
+
+/* Axis-specific only: `.wrap` also matches <main> and <footer> and
+   out-specifies them, so a `margin`/`padding` shorthand here would silently
+   drop whatever block-axis spacing those elements set for themselves. */
+.wrap { margin-inline: auto; max-width: 70rem; padding-inline: 1.5rem; }
+
+.section-label {
+    align-items: baseline;
+    color: var(--text-dim);
+    display: flex;
+    font-size: .78rem;
+    font-weight: 500;
+    gap: 1rem;
+    letter-spacing: .09em;
+    margin: 0 0 1.75rem;
+    text-transform: uppercase;
+}
+.section-label::after {
+    background: var(--border);
+    content: "";
+    flex: 1 1 1.5rem;
+    height: 1px;
+    min-width: 1.5rem;
+}
+
+
+/* ============================ gallery (index) ============================ */
+
+.hero {
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    padding: 4.5rem 0 3.5rem;
+}
+.hero h1 {
+    font-size: clamp(2rem, 5.5vw, 3.25rem);
+    font-weight: 700;
+    letter-spacing: -.025em;
+    line-height: 1.1;
+    margin: 0 0 1rem;
+}
+.tagline {
+    color: var(--text-dim);
+    font-size: clamp(1.05rem, 2.2vw, 1.3rem);
+    margin: 0 0 2rem;
+    max-width: 46rem;
+}
+.tagline strong { color: var(--text); font-weight: 500; }
+
+.actions { align-items: center; display: flex; flex-wrap: wrap; gap: .75rem; }
+code.install {
+    background: var(--bg-sunken);
+    border: 1px solid var(--border);
+    border-radius: .5rem;
+    font-family: var(--font-mono);
+    font-size: .9rem;
+    max-width: 100%;
+    overflow-x: auto;
+    padding: .6rem .9rem;
+    white-space: nowrap;
+}
+code.install::before { color: var(--text-dim); content: "$ "; }
+
+.btn {
+    border: 1px solid var(--border);
+    border-radius: .5rem;
+    font-size: .9rem;
+    font-weight: 500;
+    padding: .6rem 1rem;
+    text-decoration: none;
+    transition: background .15s, border-color .15s;
+}
+.btn:hover { background: var(--bg-sunken); border-color: var(--text-dim); }
+.btn-primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-text);
+}
+.btn-primary:hover { background: var(--accent); border-color: var(--accent); filter: brightness(1.1); }
+
+.gallery { padding-block: 4rem 1rem; }
+.grid {
+    display: grid;
+    gap: 1.75rem;
+    /* min() so a 20rem track cannot outgrow a narrower viewport. */
+    grid-template-columns: repeat(auto-fill, minmax(min(20rem, 100%), 1fr));
+    margin: 0;
+    padding: 0;
+}
+.card {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: box-shadow .2s, transform .2s;
+}
+.card:hover { box-shadow: var(--shadow-hover); transform: translateY(-2px); }
+.card.wide { grid-column: 1 / -1; }
+
+.thumb {
+    /* The visualizations draw dark text and thin strokes on an assumed light
+       ground, so the preview keeps its own light scheme in either theme. */
+    background: #fff;
+    border-bottom: 1px solid var(--border);
+    color-scheme: light;
+    display: block;
+    overflow: hidden;
+}
+.thumb img {
+    aspect-ratio: var(--thumb-aspect, 16 / 10);
+    display: block;
+    object-fit: contain;
+    padding: .5rem;
+    transition: transform .3s ease;
+    width: 100%;
+}
+.card:hover .thumb img { transform: scale(1.015); }
+
+.body { display: flex; flex-direction: column; flex: 1; gap: .5rem; padding: 1.25rem 1.35rem 1.35rem; }
+.body h2 { font-size: 1.15rem; font-weight: 700; margin: 0; }
+.body p { color: var(--text-dim); font-size: .93rem; margin: 0; }
+
+.card-foot {
+    align-items: baseline;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    margin-top: auto;
+    padding-top: .9rem;
+}
+.links-label {
+    color: var(--text-dim);
+    flex: 0 0 100%;
+    font-size: .74rem;
+    font-weight: 500;
+    letter-spacing: .07em;
+    margin: 0;
+    text-transform: uppercase;
+}
+.links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.links a {
+    background: var(--bg-sunken);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    display: inline-block;
+    font-size: .82rem;
+    padding: .25rem .7rem;
+    text-decoration: none;
+    transition: background .15s, color .15s, border-color .15s;
+}
+.links a:hover { background: var(--accent); border-color: var(--accent); color: var(--accent-text); }
+.docs { margin-left: auto; }
+.docs a { color: var(--text-dim); font-size: .82rem; text-decoration: none; white-space: nowrap; }
+.docs a:hover { color: var(--accent); text-decoration: underline; }
+
+
+/* ========================== individual examples ========================== */
+
+.topbar {
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    padding-block: .9rem;
+}
+.topbar .wrap { align-items: center; display: flex; flex-wrap: wrap; gap: .5rem; }
+.topbar a { text-decoration: none; }
+.crumb-home { color: var(--text-dim); font-size: .9rem; }
+.crumb-home:hover { color: var(--accent); text-decoration: underline; }
+.crumb-sep { color: var(--border); }
+.crumb { font-size: .9rem; font-weight: 500; }
+.topbar .docs { margin-left: auto; }
+
+.example { padding-block: 2.75rem 4rem; }
+.example h1 {
+    font-size: clamp(1.6rem, 3.5vw, 2.25rem);
+    font-weight: 700;
+    letter-spacing: -.02em;
+    line-height: 1.2;
+    margin: 0 0 .75rem;
+}
+.lede {
+    color: var(--text-dim);
+    font-size: 1.05rem;
+    margin: 0 0 2rem;
+    max-width: 48rem;
+}
+.lede code, .example p code {
+    background: var(--bg-sunken);
+    border-radius: .3rem;
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: .88em;
+    padding: .1em .35em;
+}
+
+.stage {
+    background: #fff;
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    box-shadow: var(--shadow);
+    /* Same reason as .thumb: the visualizations assume a light ground, and
+       this also keeps any scrollbar on the stage light rather than dark. */
+    color-scheme: light;
+    color: #16161a;
+    margin: 0;
+    overflow-x: auto;
+    padding: 1.25rem;
+}
+/* The visualizations are laid out at a fixed pixel size, so they are narrower
+   than the stage on a wide screen. `fit-content` shrinks the wrapper onto the
+   drawing, and auto margins then centre it; when the drawing is the wider of
+   the two the margins collapse to zero and the stage scrolls instead. */
+.stage > div { margin-inline: auto; width: fit-content; }
+/* Several examples stack more than one visualization on a single stage. */
+.stage > * + * { border-top: 1px solid #eeeef2; margin-top: 1.25rem; padding-top: 1.25rem; }
+
+.controls { display: flex; flex-wrap: wrap; gap: .6rem; margin-top: 1rem; }
+.controls button {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: .5rem;
+    color: var(--text);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: .9rem;
+    font-weight: 500;
+    padding: .5rem 1rem;
+    transition: background .15s, border-color .15s;
+}
+.controls button:hover { background: var(--bg-sunken); border-color: var(--text-dim); }
+
+.source { margin-top: 3rem; }
+.source pre {
+    background: var(--bg-sunken);
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    font-size: .85rem;
+    line-height: 1.6;
+    margin: 0;
+    overflow-x: auto;
+    padding: 1.1rem 1.25rem;
+    tab-size: 4;
+}
+.source code { font-family: var(--font-mono); }
+
+
+/* ================================ footer ================================ */
+
+footer {
+    border-top: 1px solid var(--border);
+    color: var(--text-dim);
+    font-size: .88rem;
+    margin-top: 4rem;
+    padding-block: 2.5rem 3.5rem;
+}
+footer p { margin: 0 0 .6rem; }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -1,0 +1,35 @@
+/*
+ * Shows each example page its own source.
+ *
+ * The page's module script is the single copy of the code: this reads that
+ * script back and prints it into the "Source" block, so what a reader sees is
+ * by construction the code that just ran.
+ */
+
+// On a static server the example's script is the inline one carrying
+// `data-source`. Vite's dev server rewrites inline module scripts into a
+// `src` pointing at its own copy, which drops the attribute along with the
+// element's text, so match that proxy too.
+const script = document.querySelector("script[data-source], script[src*=html-proxy]");
+const target = document.querySelector("[data-source-target]");
+
+if (script && target) {
+    let code = script.textContent;
+
+    if (!code.trim() && script.src) {
+        // The proxy hands back the same code with the import specifier
+        // resolved and a sourcemap comment appended.
+        const response = await fetch(script.src);
+        code = (await response.text()).replace(/\n*\/\/# sourceMappingURL=.*$/s, "");
+    }
+
+    const lines = code.replace(/^\s*\n/, "").trimEnd().split("\n");
+
+    // The script sits several levels deep in the markup, so every line carries
+    // that indentation. Strip the smallest amount any line has, which leaves
+    // the relative indentation of the code intact.
+    const indents = lines.filter(line => line.trim()).map(line => line.match(/^ */)[0].length);
+    const shared = Math.min(...indents);
+
+    target.textContent = lines.map(line => line.slice(shared)).join("\n");
+}

--- a/examples/heatmap-clusters.html
+++ b/examples/heatmap-clusters.html
@@ -1,51 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Heatmap example</title>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Clustered heatmap with dendrograms &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <!-- D3 v7 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Heatmap &middot; Clustered CSV</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Heatmap">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <style>
-            body {
-                margin: 0;
-            }
-        </style>
-    </head>
-    <body>
-        <div id="heatmap"></div>
+<main class="wrap example">
+  <h1>Clustered heatmap with dendrograms</h1>
+  <p class="lede">A CSV of pre-computed values, with the first column holding the row labels and every other column a
+    sample. <code>dendrogramEnabled: true</code> adds the two trees along the top and left edge, which
+    show how the rows and columns were grouped by the clustering.</p>
 
-        <script type="module">
-            import {Heatmap} from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="heatmap"></div></figure>
 
-            d3.csv("data/clusters.csv").then(data => {
-                const items = [];
-                const rows = [];
-                const columns = Object.keys(data[0]).filter(k => k !== "Family");
+<script type="module" data-source>
+    import { Heatmap } from "../dist/unipept-visualizations.js";
 
-                for (const row of data) {
-                    const newRow = [];
-                    for (const [key, value] of Object.entries(row)) {
-                        if (key === "Family") {
-                            rows.push(value);
-                        } else {
-                            newRow.push(Number.parseFloat(value));
-                        }
-                    }
-                    items.push(newRow);
-                }
+    d3.csv("data/clusters.csv").then(data => {
+        const columns = Object.keys(data[0]).filter(key => key !== "Family");
+        const rows = data.map(row => row.Family);
+        const values = data.map(row => columns.map(column => Number.parseFloat(row[column])));
 
-                const heatmapElement = document.getElementById("heatmap");
+        const element = document.getElementById("heatmap");
+        new Heatmap(element, values, rows, columns, {
+            width: 1000,
+            height: 600,
+            dendrogramEnabled: true
+        });
+    });
+</script>
 
-                if (heatmapElement) {
-                    new Heatmap(heatmapElement, items, rows, columns, {
-                        width: window.innerWidth,
-                        height: window.innerHeight - 50,
-                        dendrogramEnabled: true
-                    });
-                }
-            });
-        </script>
-    </body>
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/heatmap-random.html
+++ b/examples/heatmap-random.html
@@ -1,78 +1,71 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Heatmap example</title>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Heatmap of random values &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <!-- D3 v7 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Heatmap &middot; Random values</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Heatmap">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <style>
-            body {
-                margin: 0;
-            }
-        </style>
-    </head>
-    <body>
-        <div id="heatmap"></div>
+<main class="wrap example">
+  <h1>Heatmap of random values</h1>
+  <p class="lede">A 50 &times; 100 grid of random numbers, rendered to a canvas rather than to SVG so that grids of a
+    few hundred cells on a side stay interactive. <strong>Cluster</strong> runs UPGMA clustering and
+    animates the rows and columns into their new order; <strong>Resize</strong> redraws the same data
+    at 1000 &times; 1000 pixels.</p>
 
-        <div style="text-align: center;">
-            <button id="cluster">Cluster!</button>
-            <button id="resize">Resize!</button>
-        </div>
+  <figure class="stage"><div id="heatmap"></div></figure>
 
-        <script type="module">
-            import {Heatmap} from "../dist/unipept-visualizations.js";
+  <div class="controls">
+    <button id="cluster" type="button">Cluster</button>
+    <button id="resize" type="button">Resize</button>
+  </div>
 
-            const amountOfRows = 50;
-            const amountOfColumns = 100;
+<script type="module" data-source>
+    import { Heatmap } from "../dist/unipept-visualizations.js";
 
-            function getRandomData(rows, columns) {
-                const output = [];
+    const rowCount = 50;
+    const columnCount = 100;
 
-                for (let i = 0; i < rows; i++) {
-                    const row = [];
-                    for (let j = 0; j < columns; j++) {
-                        row.push(Math.random());
-                    }
-                    output.push(row);
-                }
+    const values = Array.from(
+        { length: rowCount },
+        () => Array.from({ length: columnCount }, () => Math.random())
+    );
+    const rows = Array.from({ length: rowCount }, (_, i) => `Family ${i}`);
+    const columns = Array.from({ length: columnCount }, (_, i) => `Sample ${i}`);
 
-                return output;
-            }
+    const element = document.getElementById("heatmap");
+    const heatmap = new Heatmap(element, values, rows, columns, {
+        width: 1000,
+        height: 600
+    });
 
-            const randomData = getRandomData(amountOfRows, amountOfColumns);
+    document.getElementById("cluster").addEventListener("click", () => heatmap.cluster());
+    document.getElementById("resize").addEventListener("click", () => heatmap.resize(1000, 1000));
+</script>
 
-            const rows = [];
-            const cols = [];
-            const grid = [];
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
 
-            for (let i = 0; i < amountOfRows; i++) {
-                rows.push("Family " + i);
-            }
-
-            for (let i = 0; i < amountOfColumns; i++) {
-                cols.push("Sample " + i);
-            }
-
-            const heatmapElement = document.getElementById("heatmap");
-
-            if (heatmapElement) {
-                let heatmap = new Heatmap(heatmapElement, randomData, rows, cols, {
-                    width: window.innerWidth,
-                    height: window.innerHeight - 50
-                });
-
-                document.getElementById("cluster")
-                    .addEventListener("click", () => {
-                        heatmap.cluster();
-                    });
-
-                document.getElementById("resize")
-                    .addEventListener("click", () => {
-                        heatmap.resize(1000, 1000);
-                    });
-            }
-        </script>
-    </body>
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,207 +3,18 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
 <title>Unipept Visualizations</title>
 <meta name="description" content="Reusable D3 visualizations for hierarchical and matrix biological data: treeview, treemap, sunburst, heatmap and barplot.">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
-<style>
-  :root {
-    --bg: #ffffff;
-    --bg-raised: #f7f7f9;
-    --bg-sunken: #eeeef2;
-    --text: #16161a;
-    --text-dim: #5b5b66;
-    --border: #dcdce4;
-    --accent: #a0248c;
-    --accent-text: #ffffff;
-    --shadow: 0 1px 2px rgba(20, 20, 30, .06), 0 8px 24px rgba(20, 20, 30, .06);
-    --shadow-hover: 0 2px 4px rgba(20, 20, 30, .08), 0 16px 40px rgba(20, 20, 30, .12);
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #101014;
-      --bg-raised: #18181e;
-      --bg-sunken: #0b0b0e;
-      --text: #f2f2f5;
-      --text-dim: #a0a0ae;
-      --border: #2a2a34;
-      --accent: #f472d0;
-      --accent-text: #1a0417;
-      --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 8px 24px rgba(0, 0, 0, .3);
-      --shadow-hover: 0 2px 4px rgba(0, 0, 0, .5), 0 16px 40px rgba(0, 0, 0, .45);
-    }
-  }
-
-  * { box-sizing: border-box; }
-  html { -webkit-text-size-adjust: 100%; }
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-    line-height: 1.6;
-    margin: 0;
-  }
-  a { color: inherit; }
-
-  /* Axis-specific only: `.wrap` also matches <main> and <footer> and
-     out-specifies them, so a `margin`/`padding` shorthand here would silently
-     drop whatever block-axis spacing those elements set for themselves. */
-  .wrap { margin-inline: auto; max-width: 70rem; padding-inline: 1.5rem; }
-
-  /* ---------- hero ---------- */
-  header {
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-raised);
-    padding: 4.5rem 0 3.5rem;
-  }
-  h1 {
-    font-size: clamp(2rem, 5.5vw, 3.25rem);
-    font-weight: 700;
-    letter-spacing: -.025em;
-    line-height: 1.1;
-    margin: 0 0 1rem;
-  }
-  .tagline {
-    color: var(--text-dim);
-    font-size: clamp(1.05rem, 2.2vw, 1.3rem);
-    margin: 0 0 2rem;
-    max-width: 46rem;
-  }
-  .tagline strong { color: var(--text); font-weight: 500; }
-
-  .actions { align-items: center; display: flex; flex-wrap: wrap; gap: .75rem; }
-  code.install {
-    background: var(--bg-sunken);
-    border: 1px solid var(--border);
-    border-radius: .5rem;
-    font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: .9rem;
-    max-width: 100%;
-    overflow-x: auto;
-    padding: .6rem .9rem;
-    white-space: nowrap;
-  }
-  code.install::before { color: var(--text-dim); content: "$ "; }
-  .btn {
-    border: 1px solid var(--border);
-    border-radius: .5rem;
-    font-size: .9rem;
-    font-weight: 500;
-    padding: .6rem 1rem;
-    text-decoration: none;
-    transition: background .15s, border-color .15s;
-  }
-  .btn:hover { background: var(--bg-sunken); border-color: var(--text-dim); }
-  .btn-primary {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: var(--accent-text);
-  }
-  .btn-primary:hover { background: var(--accent); border-color: var(--accent); filter: brightness(1.1); }
-
-  /* ---------- gallery ---------- */
-  main { padding-block: 4rem 1rem; }
-  .section-label {
-    align-items: baseline;
-    color: var(--text-dim);
-    display: flex;
-    font-size: .78rem;
-    font-weight: 500;
-    gap: 1rem;
-    letter-spacing: .09em;
-    margin: 0 0 1.75rem;
-    text-transform: uppercase;
-  }
-  .section-label::after {
-    background: var(--border);
-    content: "";
-    flex: 1 1 1.5rem;
-    height: 1px;
-    min-width: 1.5rem;
-  }
-  .grid {
-    display: grid;
-    gap: 1.75rem;
-    /* min() so a 20rem track cannot outgrow a narrower viewport. */
-    grid-template-columns: repeat(auto-fill, minmax(min(20rem, 100%), 1fr));
-    margin: 0;
-    padding: 0;
-  }
-  .card {
-    background: var(--bg-raised);
-    border: 1px solid var(--border);
-    border-radius: .75rem;
-    box-shadow: var(--shadow);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    transition: box-shadow .2s, transform .2s;
-  }
-  .card:hover { box-shadow: var(--shadow-hover); transform: translateY(-2px); }
-  .card.wide { grid-column: 1 / -1; }
-
-  .thumb {
-    background: #fff;
-    border-bottom: 1px solid var(--border);
-    display: block;
-    overflow: hidden;
-  }
-  .thumb img {
-    aspect-ratio: var(--thumb-aspect, 16 / 10);
-    display: block;
-    object-fit: contain;
-    padding: .5rem;
-    transition: transform .3s ease;
-    width: 100%;
-  }
-  .card:hover .thumb img { transform: scale(1.015); }
-
-  .body { display: flex; flex-direction: column; flex: 1; gap: .5rem; padding: 1.25rem 1.35rem 1.35rem; }
-  .body h2 { font-size: 1.15rem; font-weight: 700; margin: 0; }
-  .body p { color: var(--text-dim); font-size: .93rem; margin: 0; }
-  .links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: .5rem;
-    list-style: none;
-    margin: .5rem 0 0;
-    padding: 0;
-  }
-  .links a {
-    background: var(--bg-sunken);
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    display: inline-block;
-    font-size: .82rem;
-    padding: .25rem .7rem;
-    text-decoration: none;
-    transition: background .15s, color .15s, border-color .15s;
-  }
-  .links a:hover { background: var(--accent); border-color: var(--accent); color: var(--accent-text); }
-  .docs { margin-left: auto; }
-  .docs a { color: var(--text-dim); font-size: .82rem; text-decoration: none; }
-  .docs a:hover { color: var(--accent); text-decoration: underline; }
-  .card-foot { align-items: center; display: flex; flex-wrap: wrap; gap: .5rem; margin-top: auto; padding-top: .5rem; }
-
-  /* ---------- footer ---------- */
-  footer {
-    border-top: 1px solid var(--border);
-    color: var(--text-dim);
-    font-size: .88rem;
-    margin-top: 4rem;
-    padding-block: 2.5rem 3.5rem;
-  }
-  footer p { margin: 0 0 .6rem; }
-  footer a { color: var(--accent); text-decoration: none; }
-  footer a:hover { text-decoration: underline; }
-</style>
+<link rel="stylesheet" href="examples.css">
 </head>
 <body>
 
-<header>
+<header class="hero">
   <div class="wrap">
     <h1>Unipept Visualizations</h1>
     <p class="tagline">
@@ -220,7 +31,7 @@
   </div>
 </header>
 
-<main class="wrap">
+<main class="wrap gallery">
   <p class="section-label">Live examples</p>
   <ul class="grid">
 
@@ -230,12 +41,13 @@
         <h2>Treeview</h2>
         <p>A collapsible node&ndash;link tree. Best when you want to walk a hierarchy branch by branch and read the labels.</p>
         <div class="card-foot">
+          <p class="links-label">Open an example</p>
           <ul class="links">
             <li><a href="treeview-taxonomy.html">Taxonomy</a></li>
             <li><a href="treeview-flare.html">Flare</a></li>
-            <li><a href="treeview-multi.html">Multiple</a></li>
+            <li><a href="treeview-multi.html">Several at once</a></li>
           </ul>
-          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treeview">Docs</a></span>
+          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treeview">Docs &rarr;</a></span>
         </div>
       </div>
     </li>
@@ -246,12 +58,13 @@
         <h2>Sunburst</h2>
         <p>Concentric rings, one per level. Shows how a hierarchy divides at every depth at once, and zooms on click.</p>
         <div class="card-foot">
+          <p class="links-label">Open an example</p>
           <ul class="links">
             <li><a href="sunburst-taxonomy.html">Taxonomy</a></li>
             <li><a href="sunburst-flare.html">Flare</a></li>
-            <li><a href="sunburst-multi.html">Multiple</a></li>
+            <li><a href="sunburst-multi.html">Several at once</a></li>
           </ul>
-          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Sunburst">Docs</a></span>
+          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Sunburst">Docs &rarr;</a></span>
         </div>
       </div>
     </li>
@@ -262,12 +75,13 @@
         <h2>Treemap</h2>
         <p>Nested rectangles sized by count. The one to reach for when relative magnitude matters more than structure.</p>
         <div class="card-foot">
+          <p class="links-label">Open an example</p>
           <ul class="links">
             <li><a href="treemap-taxonomy.html">Taxonomy</a></li>
             <li><a href="treemap-flare.html">Flare</a></li>
-            <li><a href="treemap-multi.html">Multiple</a></li>
+            <li><a href="treemap-multi.html">Several at once</a></li>
           </ul>
-          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treemap">Docs</a></span>
+          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treemap">Docs &rarr;</a></span>
         </div>
       </div>
     </li>
@@ -278,10 +92,11 @@
         <h2>Barplot</h2>
         <p>Stacked bars, one per sample, with categories aligned and coloured consistently so samples compare directly.</p>
         <div class="card-foot">
+          <p class="links-label">Open an example</p>
           <ul class="links">
             <li><a href="barplot-taxonomy.html">Taxonomy</a></li>
           </ul>
-          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Barplot">Docs</a></span>
+          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Barplot">Docs &rarr;</a></span>
         </div>
       </div>
     </li>
@@ -292,11 +107,12 @@
         <h2>Heatmap</h2>
         <p>A canvas-rendered matrix with optional UPGMA clustering and dendrograms, which keeps up with grids of a few hundred by a few hundred cells.</p>
         <div class="card-foot">
+          <p class="links-label">Open an example</p>
           <ul class="links">
             <li><a href="heatmap-random.html">Random values</a></li>
             <li><a href="heatmap-clusters.html">Clustered CSV</a></li>
           </ul>
-          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Heatmap">Docs</a></span>
+          <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Heatmap">Docs &rarr;</a></span>
         </div>
       </div>
     </li>

--- a/examples/sunburst-flare.html
+++ b/examples/sunburst-flare.html
@@ -1,29 +1,58 @@
-<html>
-    <head>
-        <title>Sunburst example</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Sunburst of the flare hierarchy &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Sunburst &middot; Flare</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Sunburst">Docs &rarr;</a></span>
+  </div>
+</header>
 
-    <body>
-        <div id="d3Sunburst"></div>
+<main class="wrap example">
+  <h1>Sunburst of the flare hierarchy</h1>
+  <p class="lede">D3's <em>flare</em> sample data in a sunburst. <code>useFixedColors</code> pulls each arc's colour
+    from a fixed palette, and <code>enableTooltips: false</code> leaves the rings unannotated.</p>
 
-        <script type="module">
-            import {Sunburst} from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Sunburst"></div></figure>
 
-            d3.json("data/flare.json").then(data => {
-                new Sunburst(
-                    document.getElementById("d3Sunburst"),
-                    data,
-                    {
-                        width: 600,
-                        height: 600,
-                        enableTooltips: false,
-                        fixedColors: true
-                    }
-                );
-            });
-        </script>
-    </body>
+<script type="module" data-source>
+    import { Sunburst } from "../dist/unipept-visualizations.js";
+
+    d3.json("data/flare.json").then(data => {
+        new Sunburst(
+            document.getElementById("d3Sunburst"),
+            data,
+            {
+                width: 600,
+                height: 600,
+                enableTooltips: false,
+                useFixedColors: true
+            }
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>
-

--- a/examples/sunburst-multi.html
+++ b/examples/sunburst-multi.html
@@ -1,64 +1,93 @@
-<html>
-    <head>
-        <title>Sunburst example</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Three sunbursts on one page &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <><!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Sunburst &middot; Several at once</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Sunburst">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <script type="module">
-            import {Sunburst, StringUtils} from "../dist/unipept-visualizations.js";
+<main class="wrap example">
+  <h1>Three sunbursts on one page</h1>
+  <p class="lede">Three datasets, three sunbursts, one page. The first is a taxonomy with fixed colours keyed on name
+    and rank and a custom tooltip; the second is a single family left entirely on the defaults, so its
+    colours are blended from the level below; the third is the flare hierarchy with tooltips off.</p>
 
-            d3.json("data/taxonomy.json").then(data => {
-                const sunburst = new Sunburst(
-                    document.getElementById("sunburst1"),
-                    data,
-                    {
-                        getTooltipText: (d) => {
-                            let numberFormat = d3.format(",d");
-                            return numberFormat(!d.selfCount ? "0" : d.selfCount) + (d.selfCount && d.selfCount === 1 ? " sequence" : " sequences") +
-                                " specific to this level<br/>" + numberFormat(!d.count ? "0" : d.count) + (d.count && d.count === 1 ? " sequence" : " sequences") + " specific to this level or lower";
-                        },
-                        width: 900,
-                        height: 400,
-                        fixedColors: true,
-                        fixedColorHash: (d) => StringUtils.stringHash(d.name + " " + d.extra.rank)
-                    }
-                );
-            });
+  <figure class="stage">
+    <div id="sunburst1"></div>
+    <div id="sunburst2"></div>
+    <div id="sunburst3"></div>
+  </figure>
 
-            d3.json("data/family.json").then(data => {
-                new Sunburst(
-                    document.getElementById("sunburst2"),
-                    data,
-                    {
-                        width: 900,
-                        height: 400
-                    }
-                );
-            });
+<script type="module" data-source>
+    import { Sunburst, StringUtils } from "../dist/unipept-visualizations.js";
 
-            d3.json("data/flare.json").then(data => {
-                new Sunburst(
-                    document.getElementById("sunburst3"),
-                    data,
-                    {
-                        width: 900,
-                        height: 400,
-                        enableTooltips: false,
-                        fixedColors: true
-                    }
-                );
-            });
-        </script>
-    </head>
+    d3.json("data/taxonomy.json").then(data => {
+        const numberFormat = d3.format(",d");
+        const sequences = count => `${numberFormat(count ?? 0)} ${count === 1 ? "sequence" : "sequences"}`;
 
-    <body>
-        <div id="sunburst1"></div>
-        <div id="sunburst2"></div>
-        <div id="sunburst3"></div>
+        new Sunburst(
+            document.getElementById("sunburst1"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                useFixedColors: true,
+                fixedColorHash: d => StringUtils.stringHash(d.name + " " + d.extra.rank),
+                getTooltipText: d =>
+                    `${sequences(d.selfCount)} specific to this level<br/>` +
+                    `${sequences(d.count)} specific to this level or lower`
+            }
+        );
+    });
 
-        <script>
+    d3.json("data/family.json").then(data => {
+        new Sunburst(
+            document.getElementById("sunburst2"),
+            data,
+            {
+                width: 900,
+                height: 400
+            }
+        );
+    });
 
-        </script>
-    </body>
+    d3.json("data/flare.json").then(data => {
+        new Sunburst(
+            document.getElementById("sunburst3"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                enableTooltips: false,
+                useFixedColors: true
+            }
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/sunburst-taxonomy.html
+++ b/examples/sunburst-taxonomy.html
@@ -1,33 +1,67 @@
-<html>
-    <head>
-        <title>Sunburst example</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Sunburst of a taxonomic tree &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Sunburst &middot; Taxonomy</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Sunburst">Docs &rarr;</a></span>
+  </div>
+</header>
 
-    <body>
-        <div id="d3Sunburst"></div>
+<main class="wrap example">
+  <h1>Sunburst of a taxonomic tree</h1>
+  <p class="lede">The same taxonomy as concentric rings, one ring per level, so every depth is visible at once. Click
+    an arc to re-root the sunburst on it. <code>useFixedColors</code> draws from a fixed palette instead
+    of handing out colours in the order nodes are met, and <code>fixedColorHash</code> keys that palette
+    on name <em>and</em> rank, so a taxon keeps its colour across datasets. <code>getTooltipText</code>
+    replaces the default hit count with Unipept's own sequence counts.</p>
 
-        <script type="module">
-            import { Sunburst, StringUtils } from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Sunburst"></div></figure>
 
-            d3.json("data/taxonomy.json").then(data => {
-                new Sunburst(
-                    document.getElementById("d3Sunburst"),
-                    data,
-                    {
-                        getTooltipText: (d) => {
-                            let numberFormat = d3.format(",d");
-                            return numberFormat(!d.selfCount ? "0" : d.selfCount) + (d.selfCount && d.selfCount === 1 ? " sequence" : " sequences") +
-                                " specific to this level<br/>" + numberFormat(!d.count ? "0" : d.count) + (d.count && d.count === 1 ? " sequence" : " sequences") + " specific to this level or lower";
-                        },
-                        width: 600,
-                        height: 600,
-                        fixedColors: true,
-                        fixedColorHash: (d) => StringUtils.stringHash(d.name + " " + d.extra.rank)
-                    }
-                );
-            });
-        </script>
-    </body>
+<script type="module" data-source>
+    import { Sunburst, StringUtils } from "../dist/unipept-visualizations.js";
+
+    d3.json("data/taxonomy.json").then(data => {
+        const numberFormat = d3.format(",d");
+        const sequences = count => `${numberFormat(count ?? 0)} ${count === 1 ? "sequence" : "sequences"}`;
+
+        new Sunburst(
+            document.getElementById("d3Sunburst"),
+            data,
+            {
+                width: 600,
+                height: 600,
+                useFixedColors: true,
+                fixedColorHash: d => StringUtils.stringHash(d.name + " " + d.extra.rank),
+                getTooltipText: d =>
+                    `${sequences(d.selfCount)} specific to this level<br/>` +
+                    `${sequences(d.count)} specific to this level or lower`
+            }
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/treemap-flare.html
+++ b/examples/treemap-flare.html
@@ -1,30 +1,57 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Treemap of the flare hierarchy &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-    <head>
-        <title>Treemap example</title>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Treemap &middot; Flare</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treemap">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<main class="wrap example">
+  <h1>Treemap of the flare hierarchy</h1>
+  <p class="lede">D3's <em>flare</em> sample data with nothing configured beyond a size, so the treemap uses its
+    defaults throughout: node depth drives the colour, which runs from
+    <code>colorRoot</code> to <code>colorLeaf</code>, and tooltips are on.</p>
 
-    <body>
-        <div id="d3Treemap"></div>
-        <script type="module">
-            import {Treemap} from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Treemap"></div></figure>
 
-            d3.json("data/flare.json")
-                .then(data => {
+<script type="module" data-source>
+    import { Treemap } from "../dist/unipept-visualizations.js";
 
-                    const treemap = new Treemap(
-                        document.getElementById("d3Treemap"),
-                        data,
-                        {
-                            width: 900,
-                            height: 600
-                        },
-                    );
-                });
-        </script>
-    </body>
+    d3.json("data/flare.json").then(data => {
+        new Treemap(
+            document.getElementById("d3Treemap"),
+            data,
+            {
+                width: 900,
+                height: 600
+            }
+        );
+    });
+</script>
 
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/treemap-multi.html
+++ b/examples/treemap-multi.html
@@ -1,63 +1,98 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Three treemaps on one page &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-    <head>
-        <title>Treemap example</title>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Treemap &middot; Several at once</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treemap">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<main class="wrap example">
+  <h1>Three treemaps on one page</h1>
+  <p class="lede">The same three datasets side by side. The first colours by taxonomic rank through
+    <code>getLevel</code>. The second replaces the default blue-to-yellow ramp with
+    <code>colorRoot</code> and <code>colorLeaf</code> of its own. The third is the flare hierarchy on
+    the defaults, with tooltips off.</p>
 
-    <body>
-        <div id="treemap1"></div>
-        <br>
-        <div id="treemap2"></div>
-        <br>
-        <div id="treemap3"></div>
+  <figure class="stage">
+    <div id="treemap1"></div>
+    <div id="treemap2"></div>
+    <div id="treemap3"></div>
+  </figure>
 
-        <script type="module">
-            import {Treemap} from "../dist/unipept-visualizations.js";
+<script type="module" data-source>
+    import { Treemap } from "../dist/unipept-visualizations.js";
 
-            d3.json("data/taxonomy.json").then(data => {
-                const ranks = ["no rank", "superkingdom", "kingdom", "subkingdom", "superphylum", "phylum", "subphylum", "superclass", "class", "subclass", "infraclass", "superorder", "order", "suborder", "infraorder", "parvorder", "superfamily", "family", "subfamily", "tribe", "subtribe", "genus", "subgenus", "species group", "species subgroup", "species", "subspecies", "varietas", "forma"];
+    const ranks = [
+        "no rank", "superkingdom", "kingdom", "subkingdom", "superphylum", "phylum", "subphylum",
+        "superclass", "class", "subclass", "infraclass", "superorder", "order", "suborder",
+        "infraorder", "parvorder", "superfamily", "family", "subfamily", "tribe", "subtribe",
+        "genus", "subgenus", "species group", "species subgroup", "species", "subspecies",
+        "varietas", "forma"
+    ];
 
-                new Treemap(
-                    document.getElementById("treemap1"),
-                    data,
-                    {
-                        width: 900,
-                        height: 400,
-                        levels: ranks.length,
-                        getLevel: (d) => ranks.indexOf(d.data.extra.rank)
-                    }
-                );
-            });
+    d3.json("data/taxonomy.json").then(data => {
+        new Treemap(
+            document.getElementById("treemap1"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                levels: ranks.length,
+                getLevel: d => ranks.indexOf(d.data.extra.rank)
+            }
+        );
+    });
 
-            d3.json("data/family.json").then(data => {
-                new Treemap(
-                    document.getElementById("treemap2"),
-                    data,
-                    {
-                        width: 900,
-                        height: 400,
-                        colorRoot: "red",
-                        colorLeaf: "yellow",
-                        enableTooltips: false
-                    }
-                );
-            });
+    d3.json("data/family.json").then(data => {
+        new Treemap(
+            document.getElementById("treemap2"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                colorRoot: "red",
+                colorLeaf: "yellow",
+                enableTooltips: false
+            }
+        );
+    });
 
-            d3.json("data/flare.json").then(data => {
-                new Treemap(
-                    document.getElementById("treemap3"),
-                    data,
-                    {
-                        width: 900,
-                        height: 400,
-                        enableTooltips: false
-                    }
-                );
-            });
-        </script>
-    </body>
+    d3.json("data/flare.json").then(data => {
+        new Treemap(
+            document.getElementById("treemap3"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                enableTooltips: false
+            }
+        );
+    });
+</script>
 
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/treemap-taxonomy.html
+++ b/examples/treemap-taxonomy.html
@@ -1,31 +1,69 @@
-<html>
-    <head>
-        <title>Treemap example</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Treemap of a taxonomic tree &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Treemap &middot; Taxonomy</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treemap">Docs &rarr;</a></span>
+  </div>
+</header>
 
-    <body>
-        <div id="d3Treemap"></div>
+<main class="wrap example">
+  <h1>Treemap of a taxonomic tree</h1>
+  <p class="lede">The taxonomy as nested rectangles, each sized by the number of hits below it. Click a rectangle to
+    descend into it and use the breadcrumb bar to come back up. <code>getLevel</code> is the interesting
+    part: instead of the default node depth it returns the index of the node's taxonomic rank, so colour
+    follows rank rather than distance from the root, and <code>levels</code> tells the treemap how many
+    of those ranks exist.</p>
 
-        <script type="module">
-            import {Treemap} from "./../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Treemap"></div></figure>
 
-            d3.json("data/taxonomy.json").then(data => {
-                const ranks = ["no rank", "superkingdom", "kingdom", "subkingdom", "superphylum", "phylum", "subphylum", "superclass", "class", "subclass", "infraclass", "superorder", "order", "suborder", "infraorder", "parvorder", "superfamily", "family", "subfamily", "tribe", "subtribe", "genus", "subgenus", "species group", "species subgroup", "species", "subspecies", "varietas", "forma"];
+<script type="module" data-source>
+    import { Treemap } from "../dist/unipept-visualizations.js";
 
-                new Treemap(
-                    document.getElementById("d3Treemap"),
-                    data,
-                    {
-                        width: 900,
-                        height: 600,
-                        levels: ranks.length,
-                        getLevel: (d) => ranks.indexOf(d.data.extra.rank)
-                    }
-                );
-            });
-        </script>
-    </body>
+    const ranks = [
+        "no rank", "superkingdom", "kingdom", "subkingdom", "superphylum", "phylum", "subphylum",
+        "superclass", "class", "subclass", "infraclass", "superorder", "order", "suborder",
+        "infraorder", "parvorder", "superfamily", "family", "subfamily", "tribe", "subtribe",
+        "genus", "subgenus", "species group", "species subgroup", "species", "subspecies",
+        "varietas", "forma"
+    ];
+
+    d3.json("data/taxonomy.json").then(data => {
+        new Treemap(
+            document.getElementById("d3Treemap"),
+            data,
+            {
+                width: 900,
+                height: 600,
+                levels: ranks.length,
+                getLevel: d => ranks.indexOf(d.data.extra.rank)
+            }
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/treeview-flare.html
+++ b/examples/treeview-flare.html
@@ -1,31 +1,60 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Treeview of the flare hierarchy &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-    <head>
-        <title>Treeview example</title>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Treeview &middot; Flare</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treeview">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<main class="wrap example">
+  <h1>Treeview of the flare hierarchy</h1>
+  <p class="lede">The same treeview on D3's <em>flare</em> sample data, the package hierarchy of an old ActionScript
+    visualization toolkit. <code>levelsToExpand: 1</code> opens a single level per click rather than the
+    default two, which suits a deep and narrow tree, and <code>enableTooltips: false</code> drops the
+    hover labels because this dataset has no counts to report.</p>
 
-    <body>
-        <div id="d3Treeview"></div>
-        <script type="module">
-            import {Treeview} from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Treeview"></div></figure>
 
-            d3.json("data/flare.json")
-                .then(data => {
-                    new Treeview(
-                        document.getElementById("d3Treeview"),
-                        data,
-                        {
-                            width: 900,
-                            height: 600,
-                            levelsToExpand: 1,
-                            enableTooltips: false
-                        },
-                    );
-                });
-        </script>
-    </body>
+<script type="module" data-source>
+    import { Treeview } from "../dist/unipept-visualizations.js";
 
+    d3.json("data/flare.json").then(data => {
+        new Treeview(
+            document.getElementById("d3Treeview"),
+            data,
+            {
+                width: 900,
+                height: 600,
+                levelsToExpand: 1,
+                enableTooltips: false
+            }
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/treeview-multi.html
+++ b/examples/treeview-multi.html
@@ -1,59 +1,90 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Three treeviews on one page &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-    <head>
-        <title>Treeview example</title>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Treeview &middot; Several at once</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treeview">Docs &rarr;</a></span>
+  </div>
+</header>
 
-        <!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<main class="wrap example">
+  <h1>Three treeviews on one page</h1>
+  <p class="lede">Each visualization owns the element it is given, so several can share a page without interfering.
+    The first is a taxonomy with <code>enableExpandOnClick: false</code>, which leaves it fixed at the
+    two levels it opens with. The second overrides <code>colorProvider</code> to paint every node the
+    same colour. The third is the flare hierarchy again, opening one level at a time.</p>
 
-    <body>
-        <div id="treeview1"></div>
-        <div id="treeview2"></div>
-        <div id="treeview3"></div>
+  <figure class="stage">
+    <div id="treeview1"></div>
+    <div id="treeview2"></div>
+    <div id="treeview3"></div>
+  </figure>
 
-        <script type="module">
-            import {Treeview} from "../dist/unipept-visualizations.js";
+<script type="module" data-source>
+    import { Treeview } from "../dist/unipept-visualizations.js";
 
-            d3.json("data/taxonomy.json").then(data => {
-                new Treeview(
-                    document.getElementById("treeview1"),
-                    data,
-                    {
-                        width: 900,
-                        height: 400,
-                        enableExpandOnClick: false,
-                        enableTooltips: false,
-                    }
-                )
-            });
+    d3.json("data/taxonomy.json").then(data => {
+        new Treeview(
+            document.getElementById("treeview1"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                enableExpandOnClick: false,
+                enableTooltips: false
+            }
+        );
+    });
 
-            d3.json("data/family.json").then(data => {
-                new Treeview(
-                    document.getElementById("treeview2"),
-                    data,
-                    {
-                        colors: "steelblue",
-                        width: 900,
-                        height: 400
-                    }
-                )
-            });
+    d3.json("data/family.json").then(data => {
+        new Treeview(
+            document.getElementById("treeview2"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                colorProvider: () => "steelblue"
+            }
+        );
+    });
 
-            d3.json("data/flare.json").then(data => {
-                new Treeview(
-                    document.getElementById("treeview3"),
-                    data,
-                    {
-                        levelsToExpand: 1,
-                        width: 900,
-                        height: 400,
-                        enableExpandOnClick: false,
-                        enableTooltips: false,
-                    }
-                )
-            });
-        </script>
-    </body>
+    d3.json("data/flare.json").then(data => {
+        new Treeview(
+            document.getElementById("treeview3"),
+            data,
+            {
+                width: 900,
+                height: 400,
+                levelsToExpand: 1,
+                enableExpandOnClick: false,
+                enableTooltips: false
+            }
+        );
+    });
+</script>
 
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>

--- a/examples/treeview-taxonomy.html
+++ b/examples/treeview-taxonomy.html
@@ -1,29 +1,59 @@
-<html>
-    <head>
-        <title>Treeview example</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Treeview of a taxonomic tree &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
 
-        <!-- D3 -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
-    </head>
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Treeview &middot; Taxonomy</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Treeview">Docs &rarr;</a></span>
+  </div>
+</header>
 
-    <body>
-        <div id="d3Treeview"></div>
+<main class="wrap example">
+  <h1>Treeview of a taxonomic tree</h1>
+  <p class="lede">A Unipept taxonomic tree, drawn as a collapsible node&ndash;link diagram. Click a node to expand or
+    collapse its subtree, and hover one for its hit count. <code>colorProviderLevels: 3</code> assigns a
+    distinct colour explicitly down to the third level instead of only the root's children, so a branch
+    stays recognisable a few levels down.</p>
 
-        <script type="module">
-            import {Treeview} from "../dist/unipept-visualizations.js";
+  <figure class="stage"><div id="d3Treeview"></div></figure>
 
-            d3.json("data/taxonomy.json").then(data => {
-                new Treeview(
-                    document.getElementById("d3Treeview"),
-                    data,
-                    {
-                        width: 900,
-                        height: 600,
-                        colorProviderLevels: 3
-                    }
-                );
-            });
-        </script>
-    </body>
+<script type="module" data-source>
+    import { Treeview } from "../dist/unipept-visualizations.js";
 
+    d3.json("data/taxonomy.json").then(data => {
+        new Treeview(
+            document.getElementById("d3Treeview"),
+            data,
+            {
+                width: 900,
+                height: 600,
+                colorProviderLevels: 3
+            }
+        );
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
 </html>


### PR DESCRIPTION
The gallery page was fine, but every page behind it was bare: no doctype, no styling, and the visualization sitting alone in the top left corner. Each one now has a breadcrumb bar, a title, a paragraph on what it shows and which settings it passes, the visualization on a card, and its own source.

## Shared files

The pages carry no styles or scripts of their own any more. Two new files hold everything:

**`examples.css`** is the whole theme, for the gallery and the example pages alike. `index.html`'s inline `<style>` moved here, so there is one definition of the colours, spacing and dark mode instead of one per page. Theming switched from a `prefers-color-scheme` media query to `color-scheme: light dark` with `light-dark()` tokens, which also hands the browser its own scrollbars and controls in the right theme.

The visualizations draw dark text and thin strokes on an assumed light ground, so the card they render on keeps `color-scheme: light` in either theme, the same way the gallery thumbnails already did.

**`examples.js`** prints each page's module script into its "Source" block. The code on the page is therefore the code that ran, and cannot drift from it. Vite's dev server rewrites inline module scripts into a proxy `src`, which empties the element, so there is a fallback that fetches that proxy; on the deployed static site the text is byte for byte the script above it.

## Two settings that did nothing

I could not write an honest description of the options each page passes without first fixing two that the library does not have:

- `fixedColors: true` in `sunburst-taxonomy`, `sunburst-flare` and `sunburst-multi` (4 occurrences). The option is `useFixedColors`. Unknown keys are merged into the defaults and ignored, so those three pages were quietly falling back to sequentially assigned colours, and the `fixedColorHash` next to them had no effect either.
- `colors: "steelblue"` in `treeview-multi`. Treeview has no `colors` option; the equivalent is `colorProvider`.

This changes how the sunburst examples look. `examples/sunburst-taxonomy.png` on the gallery still shows the old blended colours, and is deliberately left alone for now.

## Smaller fixes made along the way

- `sunburst-multi.html` had a stray `<>` in its markup and its script in `<head>`.
- `treemap-taxonomy.html` imported through `./../dist/`.
- The two heatmaps sized themselves from `window.innerWidth`, which no longer suits a page that has layout around it. They take a fixed width like every other example.
- Most pages had no doctype, `lang` or `charset`.

## Manual testing

Build and serve, then walk the gallery:

```sh
npm run build && npx vite
```

<details>
<summary>What I checked</summary>

Every page was loaded in headless Chrome at 1280px wide, in both light and dark mode:

- no console errors, no page errors, no failed requests on any of the 13 pages
- every visualization container has rendered content
- every "Source" block is populated
- `lint`, `typecheck`, `build` and 37/37 tests still pass

Worth clicking through by hand: the treeview collapse/expand, the sunburst re-root on click, the treemap breadcrumb bar, and the heatmap's Cluster and Resize buttons.

</details>
