### PR TITLE
Resolve the deployed gallery's links with a base tag

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,13 +29,16 @@ jobs:
       - name: Assemble site
         # The example pages import ../dist/unipept-visualizations.js, so dist/
         # has to stay a sibling of examples/. The gallery is lifted to the root
-        # so that the site URL itself lands somewhere useful.
+        # so that the site URL itself lands somewhere useful, and a <base> makes
+        # every relative URL in that copy resolve against examples/ again. It
+        # replaces rewriting the links themselves, which only covered the
+        # patterns someone thought to list and silently 404'd on the rest.
         run: |
           mkdir -p _site
           cp -r examples _site/examples
           cp -r dist _site/dist
-          cp examples/index.html _site/index.html
-          sed -i 's|href="\([a-z0-9-]*\.html\)"|href="examples/\1"|g; s|src="\([a-z0-9-]*\.png\)"|src="examples/\1"|g' _site/index.html
+          sed 's|<head>|<head><base href="examples/">|' examples/index.html > _site/index.html
+          grep -q '<base href="examples/">' _site/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
`https://unipept.github.io/unipept-visualizations/` was serving the gallery unstyled: `examples.css` 404'd. Regression from #198.

The deploy copies `examples/index.html` to the site root, one level above where its assets live, and fixed the resulting relative URLs by rewriting them:

```sh
sed -i 's|href="\([a-z0-9-]*\.html\)"|href="examples/\1"|g; s|src="\([a-z0-9-]*\.png\)"|src="examples/\1"|g' _site/index.html
```

That only covers `.html` and `.png`, which was every relative URL the gallery had at the time. #198 gave it a stylesheet, and nothing rewrote that link.

A `<base href="examples/">` in the root copy resolves every relative URL against `examples/` in one go, including any added later, so the failure mode does not come back the next time the gallery gains an asset. The rewrites are gone.

The example pages themselves were never affected. They are served from `examples/`, where the stylesheet already sits.

## Manual testing

After merging, load `https://unipept.github.io/unipept-visualizations/` and check the gallery is styled and its links work.

<details>
<summary>What I checked locally</summary>

Reproduced the `Assemble site` step verbatim and served the result over HTTP the way Pages does, then loaded the root gallery in headless Chrome:

- 12 requests, 0 failures, no console or page errors
- the stylesheet is applied, not merely fetched (card radius 12px, label uppercase)
- clicking a card link lands on `/examples/treeview-taxonomy.html`

Then rebuilt `_site` with the old sed and confirmed the same server returns 404 for `/examples.css`, so the check does catch the bug it is meant to.

One wrinkle worth recording: the first two attempts used `sed '0,/<head>/s|...|'` and a `\n` in the replacement. Both are GNU extensions that BSD sed ignores silently, so they worked on the runner but not locally. The committed form avoids both, and a `grep -q` after the `sed` fails the job if the tag is ever missing rather than deploying a broken page again.

</details>
