### PR TITLE
Declare the package entry point with an exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
     "type": "module",
     "main": "dist/unipept-visualizations.js",
     "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/unipept-visualizations.js"
+        },
+        "./package.json": "./package.json"
+    },
     "files": [
         "dist"
     ],


### PR DESCRIPTION
`package.json` described its entry point with `main` and `types` alone, which leaves every file under `dist/` reachable as a subpath. An `exports` map states the one entry the package actually has:

```json
"exports": {
    ".": {
        "types": "./dist/index.d.ts",
        "default": "./dist/unipept-visualizations.js"
    },
    "./package.json": "./package.json"
}
```

`main` and `types` stay for tooling that predates exports maps.

## The one thing to weigh before merging

This makes `import "unipept-visualizations/dist/unipept-visualizations.js"` fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`, which is the point of the change but is a breaking change for anyone who was doing it. I could not establish whether anyone is: a GitHub code search across the org returned nothing, including for the bare package name, so it proved nothing rather than proving the absence. Worth a moment's thought about unipept-web before this goes out in a release.

The examples in this repository are unaffected. They import `../dist/unipept-visualizations.js` as a relative path, not as a package specifier.

## sideEffects, which I am deliberately not adding

I had suggested `"sideEffects": false` alongside this. I measured it and it does nothing here, so it is not in this PR. A consumer importing only `StringUtils.stringHash` builds to **72.47 kB with or without the flag**, byte for byte. The package ships as a single bundled ES module, so rollup already analyses the whole thing directly and the flag tells it nothing it did not know. It would only start to matter if the package ever shipped as separate modules.

## A pre-existing issue this uncovered, not fixed here

Under `"moduleResolution": "nodenext"` or its sibling `"node16"`, a consumer gets no types at all:

```
error TS2305: Module '"unipept-visualizations"' has no exported member 'Treeview'.
error TS2305: Module '"unipept-visualizations"' has no exported member 'StringUtils'.
```

Despite the name, `node16` is not about Node 16 the runtime. It is TypeScript's name for the mode that implements Node's real ESM resolution, exports maps and mandatory file extensions included, and `nodenext` is the current recommended setting for Node-targeted projects. The legacy mode is `node`/`node10`, which is what this repository itself used until #196 and which TypeScript 7 removed.

The cause is that the emitted declarations re-export with extensionless relative specifiers (`export * from './visualizations'`), which those modes reject. Confirmed identical with and without the exports map, so it is not a regression from this PR, and left alone rather than widening the change. Happy to open a follow-up: the contained fix looks like vite-plugin-dts's `rollupTypes`, which emits one self-contained `index.d.ts` with no relative imports left to resolve.

## Manual testing

<details>
<summary>What I verified against a real install</summary>

Built a tarball with `npm pack` and installed it into a scratch project, rather than testing against the working tree:

- `moduleResolution: bundler` type-checks clean, which is what Vite and modern setups use
- `import("unipept-visualizations")` resolves at runtime and exposes all 22 exports
- a deep import now fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`
- `moduleResolution: nodenext` and `node16` fail, identically to before the change (see above)

In this repository: `lint`, `typecheck`, `build` and 37/37 tests pass.

</details>
