### PR TITLE
Lint the whole repository, not just src

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,9 @@ import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 
 export default [
-    { ignores: ['dist/*', 'types/*', 'node_modules/*', 'examples/*'] },
+    // dist/ is build output. Everything else in the repository is linted,
+    // including the config files at the root and the examples.
+    { ignores: ['dist/'] },
 
     js.configs.recommended,
     ...typescriptPlugin.configs['flat/recommended'],
@@ -42,6 +44,22 @@ export default [
                 varsIgnorePattern: '^_',
                 caughtErrorsIgnorePattern: '^_',
             }],
+        },
+    },
+
+    {
+        // The example pages are plain scripts in a browser, so the DOM and the
+        // d3 bundle they load from a CDN are ambient rather than imported.
+        // TypeScript checks this for the .ts files, but nothing else would here.
+        files: ['examples/**/*.js'],
+        languageOptions: {
+            globals: {
+                document: 'readonly',
+                fetch: 'readonly',
+                window: 'readonly',
+                console: 'readonly',
+                d3: 'readonly',
+            },
         },
     },
 ];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "test": "vitest run",
         "test:ui": "vitest --ui",
-        "lint": "eslint \"src/**/*.ts\"",
+        "lint": "eslint .",
         "typecheck": "tsc6 --noEmit",
         "build": "vite build",
         "prepack": "npm run build",

--- a/vitest-extensions.d.ts
+++ b/vitest-extensions.d.ts
@@ -2,7 +2,7 @@
 import 'vitest';
 
 declare module 'vitest' {
-  interface Assertion<T = any> {
+  interface Assertion<_T = any> {
     toMatchImageSnapshot: (snapshotSettings?: {
       customSnapshotsDir?: string;
       customDiffDir?: string;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,6 @@
 import { expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-//@ts-ignore
 import {PNG} from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
@@ -43,19 +42,19 @@ expect.extend({
     }
 
     // Compare with existing snapshot
-    const existing = fs.readFileSync(snapshotPath);
-
     const img1 = PNG.sync.read(fs.readFileSync(snapshotPath));
     const img2 = PNG.sync.read(received);
     const {width, height} = img1;
     const diff = new PNG({width, height});
 
-    const pass = pixelmatch(img1.data, img2.data, diff.data, width, height, {threshold: failureThreshold});
+    // pixelmatch returns the number of pixels that differ, not a verdict.
+    const mismatchedCount = pixelmatch(img1.data, img2.data, diff.data, width, height, {threshold: failureThreshold});
     // Also check if the relative amount of mismatched pixels is within the threshold
-    const mismatchedPixels = (pass / (width * height));
+    const mismatchedPixels = (mismatchedCount / (width * height));
+    const matches = mismatchedPixels <= failureThreshold;
 
     // If test fails and diff directory is specified, save the received image for comparison
-    if (mismatchedPixels > failureThreshold && customDiffDir) {
+    if (!matches && customDiffDir) {
       const actualPath = path.join(customDiffDir, `actual_${snapshotName}`);
       const diffPath = path.join(customDiffDir, `diff_${snapshotName}`);
       fs.writeFileSync(actualPath, received);
@@ -63,8 +62,8 @@ expect.extend({
     }
 
     return {
-      pass: mismatchedPixels <= failureThreshold,
-      message: () => pass
+      pass: matches,
+      message: () => matches
           ? `Snapshot matches ${snapshotPath}`
           : `Snapshot does not match ${snapshotPath}. ${customDiffDir ? `See diff at ${path.join(customDiffDir, `diff_${snapshotName}`)}` : ''}`
     };


### PR DESCRIPTION
`npm run lint` globbed `src/**/*.ts` and the config ignored `examples/`, so nothing checked the config files at the root, the setup file the whole test suite runs through, or the examples. The script is now `eslint .` and the ignore list is down to `dist/`.

Six files come into scope, and they had three errors between them:

| File | Error |
| --- | --- |
| `vitest.setup.ts` | `@ts-ignore` above the `pngjs` import |
| `vitest.setup.ts` | `existing` assigned and never used |
| `vitest-extensions.d.ts` | unused generic parameter `T` |

Both suppressions turned out to be obsolete rather than load bearing, so neither needed a rule change to accommodate it:

- **`@ts-ignore` on `pngjs`** is no longer needed. `pngjs` ships its own types now, and `typecheck` passes without it.
- **the unused `T`** on the `Assertion` augmentation renames to `_T` cleanly. Interface merging is sensitive to type parameters, so this needed checking rather than assuming: `typecheck` still resolves `toMatchImageSnapshot` in the specs, which is only possible if the augmentation still merges.

The examples are plain browser scripts, so they get a small block granting the DOM and the CDN-loaded `d3` as ambient globals. TypeScript already does that job for the `.ts` files.

## A bug that was sitting next to the dead line

Removing the unused `const existing` put the matcher's return value under the nose:

```ts
const pass = pixelmatch(img1.data, img2.data, diff.data, width, height, {threshold: failureThreshold});
...
return {
  pass: mismatchedPixels <= failureThreshold,
  message: () => pass ? `Snapshot matches ...` : `Snapshot does not match ...`
};
```

`pixelmatch` returns the **number of differing pixels**, not a verdict. The `pass` property is computed correctly from the ratio, but the message uses the raw count as a boolean, so any real mismatch is a large truthy number and the failure message reads `Snapshot matches`. It is only correct when nothing differs at all.

The count is now named `mismatchedCount` and the verdict is computed once as `matches`, which both the `pass` property and the message use.

## Manual testing

Nothing to click. `npm run lint` now covers the repository.

<details>
<summary>How the message bug was verified, in both directions</summary>

Corrupted half of `Treemap.spec_..._default_settings.png` and ran the treemap specs.

With the original `vitest.setup.ts`:

```
Error: Snapshot matches /Users/.../Treemap.spec_..._default_settings.png
```

With this branch:

```
Error: Snapshot does not match /Users/.../Treemap.spec_..._default_settings.png. See diff at /Users/.../diff_Treemap.spec_..._default_settings.png
```

The snapshot was restored afterwards; `git status` shows no snapshot changes on this branch.

`lint`, `typecheck`, `build` and 37/37 tests pass.

</details>
