### PR TITLE
Clear the host element when a treemap or barplot is constructed

### DIFF
--- a/src/utilities/StyleUtilities.ts
+++ b/src/utilities/StyleUtilities.ts
@@ -1,0 +1,30 @@
+export default class StyleUtilities {
+    /**
+     * Marks an element as the host of a visualization and installs the stylesheet that belongs to it.
+     *
+     * Both steps have to survive a visualization being constructed more than once on the same element: repeating them
+     * blindly would grow the element's class attribute and leave a stale stylesheet in the document head on every
+     * construction. The stylesheet is looked up by class name and rewritten in place, so settings that end up in the
+     * CSS still take effect when a visualization is rebuilt.
+     *
+     * @param element The element the visualization is rendered in.
+     * @param className The class name the stylesheet's rules are scoped to.
+     * @param css The stylesheet's contents.
+     */
+    public static applyStyle(element: HTMLElement, className: string, css: string): void {
+        element.classList.add(className);
+
+        const document = element.ownerDocument;
+        const selector = `style[data-unipept-style="${className}"]`;
+
+        let styleElement = document.head.querySelector(selector);
+
+        if (!styleElement) {
+            styleElement = document.createElement("style");
+            styleElement.setAttribute("data-unipept-style", className);
+            document.head.appendChild(styleElement);
+        }
+
+        styleElement.textContent = css;
+    }
+}

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -3,6 +3,7 @@ import * as d3 from "d3";
 import {Bar, BarItem} from "./Bar";
 import BarplotPreprocessor from "./BarplotPreprocessor";
 import TooltipUtilities from "../../utilities/TooltipUtilities";
+import StyleUtilities from "../../utilities/StyleUtilities";
 
 export default class Barplot {
     private readonly settings: BarplotSettings;
@@ -37,6 +38,10 @@ export default class Barplot {
     }
 
     private renderBarplot(): void {
+        // Constructing a barplot on an element that already holds one has to replace it, not add a second one next to
+        // it.
+        this.element.innerHTML = "";
+
         const visElement = d3.select(this.element)
             .append("svg")
             .attr("version", "1.1")
@@ -128,9 +133,6 @@ export default class Barplot {
         } else {
             barLabelWidth = 0;
         }
-
-        // Clear previous render
-        visElement.selectAll("*").remove();
 
         const svgGElement = visElement.append("g");
 
@@ -350,10 +352,8 @@ export default class Barplot {
 
     private initCss() {
         const elementClass = this.settings.className;
-        this.element.className += " " + elementClass;
 
-        const styleElement = this.element.ownerDocument.createElement("style");
-        styleElement.appendChild(this.element.ownerDocument.createTextNode(`
+        StyleUtilities.applyStyle(this.element, elementClass, `
 .${elementClass} .barplot-item-highlighted {
     opacity: 0.5;
     transition: opacity 0.2s ease-in-out;
@@ -364,8 +364,7 @@ export default class Barplot {
     opacity: 0.5;
     transition: opacity 0.2s ease-in-out;
 }
-`))
-        this.element.ownerDocument.head.appendChild(styleElement);
+`);
     }
 
     private mouseIn(event: MouseEvent, barIndex: number, itemIndex: number) {

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -155,6 +155,23 @@ describe("Barplot", () => {
         expect(labels).toEqual(["Sample 1", "Sample 2", "Sample 3"]);
     });
 
+    it("should replace the previous barplot when constructed again on the same element", async() => {
+        const jsDom = createTestDom();
+        await createBarplot(jsDom, new BarplotSettings());
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const items = element.getElementsByClassName("barplot-item").length;
+        const children = element.children.length;
+        const styles = jsDom.window.document.head.getElementsByTagName("style").length;
+
+        await createBarplot(jsDom, new BarplotSettings());
+
+        expect(element.getElementsByClassName("barplot-item").length).toEqual(items);
+        expect(element.children.length).toEqual(children);
+        expect(jsDom.window.document.head.getElementsByTagName("style").length).toEqual(styles);
+        expect(element.className.split(/\s+/).filter((name: string) => name === "barplot")).toHaveLength(1);
+    });
+
     afterAll(async() => {
         await browser.close();
     });

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -5,6 +5,7 @@ import SunburstPreprocessor from "./SunburstPreprocessor";
 import DataNode, { DataNodeLike } from "./../../DataNode";
 import TooltipUtilities from "./../../utilities/TooltipUtilities";
 import NodeUtils from "./../../utilities/NodeUtils";
+import StyleUtilities from "./../../utilities/StyleUtilities";
 import ColorUtils from "./../../color/ColorUtils";
 
 
@@ -228,10 +229,8 @@ export default class Sunburst {
 
     private initCss() {
         const elementClass = this.settings.className;
-        this.element.className += " " + elementClass;
 
-        const styleElement = this.element.ownerDocument.createElement("style");
-        styleElement.appendChild(this.element.ownerDocument.createTextNode(`
+        StyleUtilities.applyStyle(this.element, elementClass, `
 .${elementClass} {
     font-family: Roboto,'Helvetica Neue',Helvetica,Arial,sans-serif;
     width: ${this.settings.width + this.settings.breadcrumbWidth}px;
@@ -264,8 +263,7 @@ export default class Sunburst {
 }
 .${elementClass} .sunburst-breadcrumbs .crumb .percentage {
     font-size: 11px;
-}`))
-        this.element.ownerDocument.head.appendChild(styleElement);
+}`);
     }
 
     /**

--- a/src/visualizations/treemap/Treemap.ts
+++ b/src/visualizations/treemap/Treemap.ts
@@ -2,6 +2,7 @@ import * as d3 from "d3";
 import TreemapSettings from "./TreemapSettings";
 import DataNode, { DataNodeLike } from "./../../DataNode";
 import TooltipUtilities from "./../../utilities/TooltipUtilities";
+import StyleUtilities from "./../../utilities/StyleUtilities";
 import ColorUtils from "./../../color/ColorUtils";
 import TreemapPreprocessor from "./TreemapPreprocessor";
 
@@ -67,6 +68,10 @@ export default class Treemap {
             // @ts-expect-error
             .interpolate(d3.interpolateLab);
 
+        // Constructing a treemap on an element that already holds one has to replace it, not add a second one next to
+        // it.
+        this.element.innerHTML = "";
+
         // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)
             .append("div")
@@ -122,10 +127,8 @@ export default class Treemap {
 
     private initCss() {
         const elementClass = this.settings.className;
-        this.element.className += " " + elementClass;
 
-        const styleElement = this.element.ownerDocument.createElement("style");
-        styleElement.appendChild(this.element.ownerDocument.createTextNode(`
+        StyleUtilities.applyStyle(this.element, elementClass, `
             .${elementClass} {
                 font-family: Arial,sans-serif;
             }
@@ -163,8 +166,7 @@ export default class Treemap {
                 content: " > ";
                 cursor: default;
             }
-        `));
-        this.element.ownerDocument.head.append(styleElement);
+        `);
     }
 
     private render(data: HRN<DataNode>, triggerCallback: boolean = true) {

--- a/src/visualizations/treemap/__tests__/Treemap.spec.ts
+++ b/src/visualizations/treemap/__tests__/Treemap.spec.ts
@@ -87,6 +87,23 @@ describe("Treemap", () => {
         expect(nodeFromCallback!.name).toEqual("Bacteria");
     });
 
+    it("should replace the previous treemap when constructed again on the same element", async() => {
+        const jsDom = createJSDom();
+        await createTreemap(jsDom, new TreemapSettings());
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const nodes = element.getElementsByClassName("node").length;
+        const children = element.children.length;
+        const styles = jsDom.window.document.head.getElementsByTagName("style").length;
+
+        await createTreemap(jsDom, new TreemapSettings());
+
+        expect(element.getElementsByClassName("node").length).toEqual(nodes);
+        expect(element.children.length).toEqual(children);
+        expect(jsDom.window.document.head.getElementsByTagName("style").length).toEqual(styles);
+        expect(element.className.split(/\s+/).filter((name: string) => name === "treemap")).toHaveLength(1);
+    });
+
     afterAll(async() => {
         await browser.close();
     });


### PR DESCRIPTION
## The bug

`Treeview`, `Sunburst` and `Heatmap` all start their constructor's DOM setup with `this.element.innerHTML = ""`. `Treemap` and `Barplot` did not, so constructing one of them again on an element that already held one appended a second copy next to the first instead of replacing it.

Confirmed by constructing each visualization twice on the same element in JSDOM:

| | treemap `.node` | treemap top-level children | barplot `.barplot-item` | barplot top-level children |
| --- | --- | --- | --- | --- |
| before, after 1 construction | 331 | 2 | 6 | 1 |
| before, after 2 constructions | 662 | 4 | 12 | 2 |
| after the fix, 2 constructions | 331 | 2 | 6 | 1 |

Re-rendering an existing instance (`reset()`, `reroot()`, `resize()`) was already correct: that path uses a keyed d3 data join with `exit().remove()`. Only re-instantiation duplicated, and that path is untouched.

`initCss()` leaked in the same way, in all three visualizations that have one (treemap, barplot, sunburst): it appended a new `<style>` element to the document head and did `this.element.className += " " + elementClass` on every construction, so two constructions left 2 stylesheets and a class attribute of `" treemap treemap"`.

## What changed

- `Treemap` and `Barplot` clear their host element before rendering into it.
- The stylesheet handling moved into a new internal `StyleUtilities.applyStyle`, used by the treemap, the barplot and the sunburst. It tags the `<style>` element with `data-unipept-style="<className>"`, reuses the one that is already in the head, and rewrites its contents rather than appending a second one. Rewriting instead of skipping matters for the sunburst, whose CSS contains a width taken from the settings. The class name goes on through `classList.add`, which is idempotent.
- Removed a `visElement.selectAll("*").remove()` in `Barplot.renderBarplot`, commented "Clear previous render". It ran on an `<svg>` that had just been created and was therefore a no-op, and its comment claimed to do what this PR actually fixes.
- `StyleUtilities` is internal, like `TooltipUtilities`. It is not exported from `src/utilities/index.ts`, so the public API is unchanged.

`Treeview` and `Heatmap` have no `initCss` and already cleared their element, so they needed no change.

## Manual testing

Not tested in a browser. Verified in JSDOM through the test suite, including the existing puppeteer image snapshots, which still match, so the rendered output is unchanged.

<details>
<summary>Verified</summary>

- The two new tests fail on `main` with the numbers in the table above (`expected 662 to deeply equal 331` and `expected 12 to deeply equal 6`), and pass with the fix. Checked by stashing only the source changes and re-running the new tests.
- `npm run lint`: clean.
- `npm run typecheck`: clean.
- `npm test`: 14 files, 67 tests passing (65 before, plus the 2 new ones). The image snapshot tests for the treemap, sunburst, barplot, treeview and heatmap all still match.

</details>

Closes #130
