### PR TITLE
Keep sunburst labels on screen across a render

### DIFF
--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -42,6 +42,14 @@ export default class Sunburst {
     private arcData: HRN<DataNode>[] = [];
     private textData: HRN<DataNode>[] = [];
 
+    /**
+     * Key under which a node's label is joined to its <text> element. The ids of
+     * the data nodes cannot be used here: every `empty` filler node produced by
+     * the preprocessor carries the same id, so only the hierarchy node itself
+     * identifies a label.
+     */
+    private readonly textKeys: Map<HRN<DataNode>, string> = new Map();
+
     private previousRoot: HRN<DataNode> | null = null;
     private previousMaxLevel: number = this.currentMaxLevel;
 
@@ -71,6 +79,7 @@ export default class Sunburst {
 
         const partition = d3.partition<DataNode>();
         this.data = partition(rootNode).descendants();
+        this.data.forEach((node: HRN<DataNode>, i: number) => this.textKeys.set(node, i.toString()));
 
         this.arc = d3.arc<HRN<DataNode>>()
             .startAngle((d: HRN<DataNode>) => Math.max(0, Math.min(Math.PI * 2, this.xScale(d.x0))))
@@ -450,24 +459,43 @@ export default class Sunburst {
             ctx.font = ctx!.font = "16px 'Helvetica Neue', Helvetica, Arial, sans-serif"
         }
 
-        // Remove old text nodes
-        this.visGElement.selectAll("text").data([]).exit().remove();
+        const labels = this.visGElement.selectAll<SVGTextElement, HRN<DataNode>>("text")
+            .data(data, (d: HRN<DataNode>) => this.textKeys.get(d)!);
 
-        // Add new text nodes
-        this.text = this.visGElement.selectAll("text").data(data).enter().append("text")
-            .style("fill", (d: HRN<DataNode>) => ColorUtils.getReadableColorFor(this.color(d.data)))
+        labels.exit().remove();
+
+        // Labels that were already on screen are deliberately not re-created: they
+        // keep their DOM element, and with it their current opacity, so that only
+        // their position is animated.
+        this.text = labels.enter()
+            .append("text")
             .style("fill-opacity", 0)
             .style("font-family", "font-family: Helvetica, 'Super Sans', sans-serif")
             .style("pointer-events", "none") // don't invoke mouse events
             .attr("dy", ".2em")
+            .merge(labels)
+            .style("fill", (d: HRN<DataNode>) => ColorUtils.getReadableColorFor(this.color(d.data)))
+            // A previous render may have left this label hidden; from here on its
+            // opacity alone decides whether it shows.
+            .style("visibility", null)
             .text((d: HRN<DataNode>) => this.settings.getLabel(d.data))
             .style("font-size", function(this: SVGTextContentElement, _d: HRN<DataNode>) {
                 const txtLength = offscreenCanvasSupported ? ctx.measureText(this.textContent!).width : this.getComputedTextLength();
                 return Math.floor(Math.min(((that.settings.radius / that.settings.levels) / txtLength * 10) + 1, 12)) + "px";
-            });
+            })
+            // renderArcs re-appends every arc on each render, so the labels have to
+            // be lifted back above them.
+            .raise();
 
         // Somewhat of a hack as we rely on arcTween updating the scales.
         await new Promise<void>((resolve) => {
+            // A transition never reports an end for an empty selection, which would
+            // leave this promise pending forever.
+            if (this.text.empty()) {
+                resolve();
+                return;
+            }
+
             this.text
                 .transition().duration(this.settings.animationDuration)
                 .attrTween("text-anchor", (d: HRN<DataNode>) => {
@@ -484,17 +512,23 @@ export default class Sunburst {
                 })
                 .styleTween("fill-opacity", function(this: SVGTextContentElement, e: HRN<DataNode>) {
                     const selectedFontSize = Number.parseInt(d3.select(this).style("font-size").replace("px", ""))
+                    // Fade in from wherever this label already is: a label that survives
+                    // this render is at full opacity and has to stay there.
+                    const startOpacity = Number.parseFloat(d3.select(this).style("fill-opacity")) || 0;
 
                     return (t: number) => {
                         const availableSpace = that.computeAvailableSpace(e);
 
                         if (availableSpace > selectedFontSize) {
-                            return t.toString();
+                            return (startOpacity + (1 - startOpacity) * t).toString();
                         } else {
                             return "0";
                         }
                     }
                 })
+                // The next render interrupts this transition before it ends, and an
+                // interrupted transition reports no end.
+                .on("interrupt.resolve cancel.resolve", () => resolve())
                 .on("end", function(this: SVGTextContentElement, e: HRN<DataNode>) {
                     const availableSpace = that.computeAvailableSpace(e);
                     const node = d3.select(this);

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -50,6 +50,13 @@ export default class Sunburst {
      */
     private readonly textKeys: Map<HRN<DataNode>, string> = new Map();
 
+    /**
+     * Incremented on every reroot. A render whose animation is interrupted by a
+     * newer one must not publish the view it was drawing afterwards, or the next
+     * render joins its labels on a view that is no longer on screen.
+     */
+    private renderGeneration: number = 0;
+
     private previousRoot: HRN<DataNode> | null = null;
     private previousMaxLevel: number = this.currentMaxLevel;
 
@@ -367,6 +374,7 @@ export default class Sunburst {
 
         // perform animation
         this.currentMaxLevel = d.depth + this.settings.levels;
+        this.renderGeneration++;
 
         this.renderArcs(d);
         this.renderText(d);
@@ -433,6 +441,8 @@ export default class Sunburst {
     }
 
     private async renderText(parentNode: HRN<DataNode>) {
+        const generation = this.renderGeneration;
+
         const filteredData = this.data.filter((e: HRN<DataNode>) => {
             return NodeUtils.isParentOf(parentNode, e, this.currentMaxLevel);
         });
@@ -542,7 +552,9 @@ export default class Sunburst {
                 });
         });
 
-        this.textData = filteredData;
+        if (generation === this.renderGeneration) {
+            this.textData = filteredData;
+        }
     }
 
     private setBreadcrumbs(d: HRN<DataNode>) {

--- a/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
+++ b/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
@@ -1,5 +1,5 @@
 import Sunburst from "./../Sunburst";
-import { waitForCondition } from "./../../../test/TestUtils";
+import { waitForCondition, waitForPromises } from "./../../../test/TestUtils";
 import SunburstSettings from "./../SunburstSettings";
 import DataNode from "./../../../DataNode";
 import TestConsts from "./../../../test/TestConsts";
@@ -96,6 +96,47 @@ describe("Sunburst", () => {
         const image = await page.screenshot();
 
         expect(image).toMatchImageSnapshot(TestConsts.resolveImageSnapshotFolder(__filename));
+    });
+
+    it("should keep the labels that survive a reroot on screen during the animation", async() => {
+        const dom = createJSDom();
+
+        const element = dom.window.document.getElementById("visualization")!;
+
+        const settings = new SunburstSettings();
+        // Long enough that the assertions below land well before the animation ends.
+        settings.animationDuration = 1000;
+
+        new Sunburst(element, taxonomyObject, settings);
+
+        const labelFor = (name: string) =>
+            Array.from(element.getElementsByTagName("text")).find(t => t.textContent === name);
+        const opacityOf = (label: SVGTextElement) =>
+            Number.parseFloat(label.style.getPropertyValue("fill-opacity"));
+
+        // Wait for the initial animation to have faded the labels in completely.
+        await waitForCondition(() => {
+            const label = labelFor("Eukaryota");
+            return !!label && opacityOf(label) === 1;
+        }, 5000, 100);
+
+        const before = labelFor("Eukaryota")!;
+        expect(before).toBeDefined();
+        expect(opacityOf(before)).toEqual(1);
+
+        // new Event("click") does apparently not work in combination with Jest and JSDOM
+        const event = dom.window.document.createEvent("CustomEvent");
+        event.initEvent("click", true, true);
+
+        // Reroot on Eukaryota, which keeps its own label and the labels of its children.
+        element.getElementsByTagName("path").item(1)!.dispatchEvent(event);
+
+        await waitForPromises(50);
+
+        const during = labelFor("Eukaryota")!;
+        // A recreated label would be a different element sitting at zero opacity.
+        expect(during).toBe(before);
+        expect(opacityOf(during)).toEqual(1);
     });
 
     it("should trigger a custom callback when a node is clicked", async() => {

--- a/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
+++ b/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
@@ -24,6 +24,37 @@ describe("Sunburst", () => {
         return dom;
     }
 
+    function labelsOf(element: HTMLElement): string[] {
+        return Array.from(element.getElementsByTagName("text"))
+            .map((label: SVGTextElement) => label.textContent!)
+            .filter((text: string) => text.length > 0)
+            .sort();
+    }
+
+    function opacityOfLabel(element: HTMLElement, name: string): number {
+        const label = Array.from(element.getElementsByTagName("text")).find(l => l.textContent === name);
+        return label ? Number.parseFloat(label.style.getPropertyValue("fill-opacity")) : 0;
+    }
+
+    function visibleLabelsOf(element: HTMLElement): string[] {
+        return Array.from(element.getElementsByTagName("text"))
+            .filter((label: SVGTextElement) => Number.parseFloat(label.style.getPropertyValue("fill-opacity")) > 0.5)
+            .map((label: SVGTextElement) => label.textContent!)
+            .filter((text: string) => text.length > 0)
+            .sort();
+    }
+
+    function clickArcOf(dom: JSDOM, element: HTMLElement, name: string) {
+        const arc = Array.from(element.getElementsByTagName("path"))
+            .find((path: any) => path.__data__?.data?.name === name);
+        expect(arc).toBeDefined();
+
+        // new Event("click") does apparently not work in combination with Jest and JSDOM
+        const event = dom.window.document.createEvent("CustomEvent");
+        event.initEvent("click", true, true);
+        arc!.dispatchEvent(event);
+    }
+
     async function createScreenshotForSunburst(settings: SunburstSettings): Promise<any> {
         const dom = createJSDom();
 
@@ -138,6 +169,51 @@ describe("Sunburst", () => {
         expect(during).toBe(before);
         expect(opacityOf(during)).toEqual(1);
     });
+
+    it("should not draw a render on the view of a render that was interrupted", async() => {
+        const animationDuration = 400;
+        // Comfortably longer than an animation, which runs on wall clock time.
+        const settled = 3 * animationDuration;
+
+        /**
+         * Reroot on each of the given nodes in turn, waiting the matching amount of
+         * milliseconds after each of the clicks.
+         */
+        const drillDown = async(names: string[], gaps: number[]) => {
+            const dom = createJSDom();
+            const element = dom.window.document.getElementById("visualization")!;
+
+            const settings = new SunburstSettings();
+            settings.animationDuration = animationDuration;
+
+            new Sunburst(element, taxonomyObject, settings);
+            await waitForCondition(() => opacityOfLabel(element, "Eukaryota") === 1, 5000, 100);
+
+            const rootLabels = labelsOf(element);
+
+            for (let i = 0; i < names.length; i++) {
+                clickArcOf(dom, element, names[i]);
+                await waitForPromises(gaps[i]);
+            }
+
+            return { rootLabels, labels: labelsOf(element), visible: visibleLabelsOf(element) };
+        };
+
+        // Labels that are only drawn while Eukaryota is the root.
+        const eukaryota = await drillDown(["Eukaryota"], [settled]);
+        const eukaryotaOnly = eukaryota.labels.filter((label: string) => !eukaryota.rootLabels.includes(label));
+        expect(eukaryotaOnly.length).toBeGreaterThan(0);
+
+        const path = ["Eukaryota", "Bacteria", "Proteobacteria"];
+        const slowly = await drillDown(path, [settled, settled, settled]);
+        // The second click supersedes the Eukaryota render long before it ends, so
+        // the third one may not join its labels on the view that render was drawing.
+        const rapidly = await drillDown(path, [60, 140, settled]);
+
+        expect(rapidly.labels.filter((label: string) => eukaryotaOnly.includes(label))).toEqual([]);
+        // Which labels end up on screen may not depend on how fast the clicks came in.
+        expect(rapidly.visible).toEqual(slowly.visible);
+    }, 30000);
 
     it("should trigger a custom callback when a node is clicked", async() => {
         const dom = createJSDom();


### PR DESCRIPTION
The labels of the sunburst disappeared at the start of every animation and only came back halfway through it.

`renderText` threw away the whole label layer on each render (`selectAll("text").data([]).exit().remove()`) and then re-appended every label with `fill-opacity: 0`, tweening the opacity back to 1 over `animationDuration`. Labels that were on screen before the click and stayed on screen after it were therefore faded out and back in for no reason, and since the default easing is cubic in-out they stayed close to invisible for roughly the first half of the animation.

The labels are now joined on the hierarchy node (the node itself, not `data.id`, because every `empty` filler node shares the same id). Labels that survive a render keep their `<text>` element and their current opacity and only get their position, anchor and font size updated, new labels still fade in from zero, and labels that dropped out of the view are removed. The opacity tween interpolates from the label's current opacity instead of always from zero, so a label already at 1 stays at 1. Two smaller things came with it: the surviving labels are raised back above the arcs (`renderArcs` re-appends every path on each render) and the promise `renderText` awaits now also settles when the selection is empty or when the next render interrupts the transition.

## Only the current render publishes its view

`renderText` ends by assigning the view it drew to `textData`, which is what the next render joins its labels on. That assignment happens after the animation, so a render that was superseded still performed it. This is not new: on `main` the superseded render's transition ran to completion on detached elements and fired `end` at its natural time. Resolving on `interrupt` moved that write to the moment the next render starts, which is early enough for it to poison the join of the render after that. With three rapid clicks the third render then joined on a view that was never finished and re-created labels belonging to a subtree that had already been left behind.

The assignment is now guarded by a render generation counter that `click` increments, so only the render that is still the current one publishes.

`renderArcs` has the same shape but is not affected. It removes and re-appends every path on each render, so its transitions are never interrupted and each render's `end` fires one full `animationDuration` after it started, which for a constant duration means the newest render always writes `arcData` last. That ordering is incidental rather than designed: mutating `settings.animationDuration` between two clicks would break it. It was left alone because guarding it would change which arcs are kept on screen during an overlapping animation, without a defect to point at.

## Manual testing

Open `examples/sunburst-taxonomy.html` after `npm run build` and click an arc to re-root. The labels that belong to the new view should stay legible for the whole animation instead of blinking out and reappearing halfway. Rapidly clicking several arcs in a row should behave the same, and the labels should never end up painted underneath an arc.

<details>
<summary>What was verified</summary>

**Labels staying on screen.** Driven with puppeteer on `examples/sunburst-taxonomy.html`, clicking the `Eukaryota` arc (`animationDuration` 1000 ms) and sampling `fill-opacity` of the 21 labels that are on screen both before and after the click:

| time after click | mean opacity before | mean opacity after |
| --- | --- | --- |
| 16 ms | 0.000 | 1.000 |
| 33 ms | 0.000 | 1.000 |
| 50 ms | 0.001 | 1.000 |
| 100 ms | 0.004 | 1.000 |
| 250 ms | 0.063 | 1.000 |
| 500 ms | 0.454 | 0.905 |

Before the change 0 of those 21 labels reused their DOM element, after it 20 of 21 do (the 21st is a duplicate label text, not the same node).

Screenshots of the same page: the initial render and the settled state after the re-root are pixel identical before and after the change (0 differing pixels each, via pixelmatch); only the mid-animation frame differs (0.25% of pixels).

**The generation guard.** Measured in jsdom, drilling `Eukaryota` then `Bacteria` then `Proteobacteria`, once with the clicks 1200 ms apart and once with gaps of 60 ms and 140 ms against a 400 ms animation. In both runs the settled set of *visible* labels was the same, 16 labels, with or without the guard, so this does not produce visibly wrong settled output in that reproduction. What differed is which `<text>` elements the join carried: without the guard the rapid run retained `Craniata`, a label that exists only in the `Eukaryota` view that was interrupted and never finished, so the third render had joined on that superseded view. With the guard it retains only labels from the last view that actually completed. One further settled click flushes the difference either way.

**Tests.** `npm run lint`, `npm run typecheck` and `npm test` (69 tests, two of them added here) pass on top of `df6c3a5`. The four existing sunburst image snapshots still match and were not regenerated. The label persistence test fails on `main`. The interrupted render test passes on `main`, fails on this branch without the generation guard (`expected [ 'Craniata' ] to deeply equal []`) and passes with it, which places that race squarely on the `interrupt` handler added here.
</details>

Closes #181
