### PR TITLE
Add an optional legend to the heatmap

### DIFF
--- a/examples/heatmap-legend.html
+++ b/examples/heatmap-legend.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Heatmap with a legend &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Heatmap &middot; Legend</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Heatmap">Docs &rarr;</a></span>
+  </div>
+</header>
+
+<main class="wrap example">
+  <h1>Heatmap with a legend</h1>
+  <p class="lede"><code>enableLegend: true</code> puts a color bar underneath the grid that maps the colors of the
+    cells onto the values they stand for. The bar shows the same discrete color buckets that the grid uses, and
+    <code>legend.title</code> and <code>legend.tickFormat</code> label it. The legend takes its height out of the
+    configured one, so the visualization as a whole still measures 1000 &times; 600 pixels.
+    <strong>Toggle legend</strong> rebuilds the heatmap with the legend off, which shows how much room it takes.</p>
+
+  <figure class="stage"><div id="heatmap"></div></figure>
+
+  <div class="controls">
+    <button id="legend" type="button">Toggle legend</button>
+    <button id="cluster" type="button">Cluster</button>
+    <button id="resize" type="button">Resize</button>
+  </div>
+
+<script type="module" data-source>
+    import { Heatmap } from "../dist/unipept-visualizations.js";
+
+    const rowCount = 25;
+    const columnCount = 50;
+
+    const values = Array.from(
+        { length: rowCount },
+        () => Array.from({ length: columnCount }, () => Math.random())
+    );
+    const rows = Array.from({ length: rowCount }, (_, i) => `Family ${i}`);
+    const columns = Array.from({ length: columnCount }, (_, i) => `Sample ${i}`);
+
+    const element = document.getElementById("heatmap");
+
+    let legendEnabled = true;
+    let heatmap;
+
+    // The legend is set up when the heatmap is constructed, so toggling it means building a new heatmap.
+    const render = () => {
+        heatmap = new Heatmap(element, values, rows, columns, {
+            width: 1000,
+            height: 600,
+            enableLegend: legendEnabled,
+            legend: {
+                title: "Similarity",
+                width: 320,
+                tickFormat: value => `${(value * 100).toFixed(0)}%`
+            }
+        });
+    };
+
+    render();
+
+    document.getElementById("legend").addEventListener("click", () => {
+        legendEnabled = !legendEnabled;
+        render();
+    });
+    document.getElementById("cluster").addEventListener("click", () => heatmap.cluster());
+    document.getElementById("resize").addEventListener("click", () => heatmap.resize(1000, 400));
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
+</html>

--- a/examples/heatmap-legend.html
+++ b/examples/heatmap-legend.html
@@ -29,7 +29,8 @@
     cells onto the values they stand for. The bar shows the same discrete color buckets that the grid uses, and
     <code>legend.title</code> and <code>legend.tickFormat</code> label it. The legend takes its height out of the
     configured one, so the visualization as a whole still measures 1000 &times; 600 pixels.
-    <strong>Toggle legend</strong> rebuilds the heatmap with the legend off, which shows how much room it takes.</p>
+    <strong>Toggle legend</strong> rebuilds the heatmap with the legend off, which shows how much room it takes, and
+    <strong>Export SVG</strong> downloads the heatmap as an SVG file with the same legend underneath it.</p>
 
   <figure class="stage"><div id="heatmap"></div></figure>
 
@@ -37,6 +38,7 @@
     <button id="legend" type="button">Toggle legend</button>
     <button id="cluster" type="button">Cluster</button>
     <button id="resize" type="button">Resize</button>
+    <button id="export" type="button">Export SVG</button>
   </div>
 
 <script type="module" data-source>
@@ -79,6 +81,16 @@
     });
     document.getElementById("cluster").addEventListener("click", () => heatmap.cluster());
     document.getElementById("resize").addEventListener("click", () => heatmap.resize(1000, 400));
+    document.getElementById("export").addEventListener("click", () => {
+        const url = URL.createObjectURL(new Blob([heatmap.toSVG()], { type: "image/svg+xml" }));
+
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = "heatmap.svg";
+        link.click();
+
+        URL.revokeObjectURL(url);
+    });
 </script>
 
   <section class="source">

--- a/examples/index.html
+++ b/examples/index.html
@@ -111,6 +111,7 @@
           <ul class="links">
             <li><a href="heatmap-random.html">Random values</a></li>
             <li><a href="heatmap-clusters.html">Clustered CSV</a></li>
+            <li><a href="heatmap-legend.html">Legend</a></li>
           </ul>
           <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Heatmap">Docs &rarr;</a></span>
         </div>

--- a/src/visualizations/heatmap/Heatmap.ts
+++ b/src/visualizations/heatmap/Heatmap.ts
@@ -6,6 +6,7 @@ import {Reorderer} from "./reorder/Reorderer";
 import {HeatmapFeature} from "./HeatmapFeature";
 import {HeatmapValue} from "./HeatmapValue";
 import Preprocessor from "./Preprocessor";
+import {VisualizationPadding} from "./../../Settings";
 
 import CanvasRenderHelper from "./../../render/CanvasRenderHelper";
 import RenderHelper from "./../../render/RenderHelper";
@@ -19,6 +20,9 @@ type ViewPort = {
 
 const LEGEND_FONT_FAMILY = "'Helvetica Neue', Helvetica, Arial, sans-serif";
 
+// The color for the lowest value is a very light one by default, so the color bar is outlined to keep it visible.
+const LEGEND_OUTLINE_COLOR = "rgba(0, 0, 0, 0.2)";
+
 // Vertical space (in pixels) between the legend's title and its color bar.
 const LEGEND_TITLE_SPACING = 6;
 
@@ -27,6 +31,19 @@ const LEGEND_LABEL_SPACING = 8;
 
 // Length (in pixels) of the tick marks underneath the legend's color bar.
 const LEGEND_TICK_LENGTH = 4;
+
+// A canvas with a height of zero or less is invalid: browsers fall back to their default height of 150 pixels, which
+// makes the visualization taller than requested instead of smaller.
+const MINIMUM_GRID_HEIGHT = 1;
+
+/**
+ * One of the primitives that a legend is built out of. Positions are relative to the top left corner of the legend's
+ * content (thus with the legend's padding already applied).
+ */
+type LegendShape =
+    { type: "rect", x: number, y: number, width: number, height: number, fill: string, stroke?: string } |
+    { type: "line", x1: number, y1: number, x2: number, y2: number, stroke: string } |
+    { type: "text", x: number, y: number, fontSize: number, anchor: string, content: string };
 
 export default class Heatmap {
     private element: HTMLElement;
@@ -156,10 +173,17 @@ export default class Heatmap {
     private fillOptions(options: any = undefined): HeatmapSettings {
         const output = new HeatmapSettings();
         Object.assign(output, options);
-        // Object.assign is shallow, so a legend object that only mentions some of the settings would otherwise wipe
-        // out the defaults for all the others.
-        output.legend = Object.assign(new HeatmapLegendSettings(), options?.legend);
+        output.legend = this.fillGroup(new HeatmapLegendSettings(), options?.legend);
         return output;
+    }
+
+    /**
+     * Object.assign is shallow, so a settings group that only mentions some of its settings would wipe out the
+     * defaults for all the others. The padding nested inside such a group needs the same treatment.
+     */
+    private fillGroup<T extends { padding: VisualizationPadding }>(defaults: T, options: any): T {
+        const padding = Object.assign({}, defaults.padding, options?.padding);
+        return Object.assign(defaults, options, { padding });
     }
 
     /**
@@ -330,9 +354,12 @@ export default class Heatmap {
     /**
      * Height that's available to the heatmap grid itself. The legend is rendered underneath the grid and takes away
      * part of the configured height, so that the visualization as a whole keeps the dimensions that were requested.
+     * A grid that no longer fits is clamped instead of refused: heatmaps are commonly resized to whatever a container
+     * happens to measure, and throwing on a container that's briefly smaller than the legend is worse than a
+     * visualization that ends up a few pixels taller than asked for.
      */
     private get gridHeight(): number {
-        return this.settings.height - this.legendHeight();
+        return Math.max(MINIMUM_GRID_HEIGHT, this.settings.height - this.legendHeight());
     }
 
     private canvasStyle(): string {
@@ -362,44 +389,36 @@ export default class Heatmap {
     }
 
     /**
-     * Render the color bar that maps the colors used by the grid onto the values they represent. Does nothing when the
-     * legend is disabled.
+     * Width (in pixels) of the legend's color bar, given the width that's available to the legend as a whole.
      */
-    private renderLegend() {
-        if (!this.legendElement) {
-            return;
-        }
-
+    private legendBarWidth(availableWidth: number): number {
         const legend = this.settings.legend;
-        const height = this.legendHeight();
-        const barWidth = Math.max(
-            1,
-            Math.min(legend.width, this.settings.width - legend.padding.left - legend.padding.right)
-        );
 
-        this.legendElement
-            .attr("width", this.settings.width)
-            .attr("height", height)
-            .attr("style", `display: block; width: ${this.settings.width}px; height: ${height}px`);
+        return Math.max(1, Math.min(legend.width, availableWidth - legend.padding.left - legend.padding.right));
+    }
 
-        this.legendElement.selectAll("*").remove();
-
-        const container = this.legendElement
-            .append("g")
-            .attr("class", "legend")
-            .attr("transform", `translate(${legend.padding.left}, ${legend.padding.top})`)
-            .attr("font-family", LEGEND_FONT_FAMILY)
-            .attr("fill", this.settings.labelColor);
+    /**
+     * Compute the primitives that the legend is built out of. Both the legend that's rendered next to the canvas and
+     * the one that's written into the exported SVG are produced from this, so that the two cannot drift apart.
+     *
+     * @param barWidth Width (in pixels) that the color bar should take up.
+     * @return All shapes of the legend, positioned relative to the top left corner of the legend's content.
+     */
+    private computeLegendShapes(barWidth: number): LegendShape[] {
+        const legend = this.settings.legend;
+        const shapes: LegendShape[] = [];
 
         const barTop = legend.title ? legend.titleFontSize + LEGEND_TITLE_SPACING : 0;
 
         if (legend.title) {
-            container.append("text")
-                .attr("x", 0)
-                .attr("y", 0)
-                .attr("font-size", legend.titleFontSize)
-                .attr("dominant-baseline", "hanging")
-                .text(legend.title);
+            shapes.push({
+                type: "text",
+                x: 0,
+                y: 0,
+                fontSize: legend.titleFontSize,
+                anchor: "start",
+                content: legend.title
+            });
         }
 
         // Render the palette that the grid itself uses instead of a smooth gradient, so that the legend also shows how
@@ -415,23 +434,26 @@ export default class Heatmap {
         for (const [idx, color] of palette.entries()) {
             const x = idx * bucketWidth;
 
-            container.append("rect")
-                .attr("x", x)
-                .attr("y", barTop)
+            shapes.push({
+                type: "rect",
+                x: x,
+                y: barTop,
                 // Overlap the next bucket, since fractional widths otherwise leave hairlines between the buckets.
-                .attr("width", Math.min(bucketWidth + 1, barWidth - x))
-                .attr("height", legend.height)
-                .attr("fill", color);
+                width: Math.min(bucketWidth + 1, barWidth - x),
+                height: legend.height,
+                fill: color
+            });
         }
 
-        // The color for the lowest value is a very light one by default, so outline the bar to keep it visible.
-        container.append("rect")
-            .attr("x", 0.5)
-            .attr("y", barTop + 0.5)
-            .attr("width", barWidth - 1)
-            .attr("height", legend.height - 1)
-            .attr("fill", "none")
-            .attr("stroke", "rgba(0, 0, 0, 0.2)");
+        shapes.push({
+            type: "rect",
+            x: 0.5,
+            y: barTop + 0.5,
+            width: barWidth - 1,
+            height: legend.height - 1,
+            fill: "none",
+            stroke: LEGEND_OUTLINE_COLOR
+        });
 
         const scale = d3.scaleLinear().domain([0, 1]).range([0, barWidth]);
         const ticks = scale.ticks(legend.ticks);
@@ -440,27 +462,107 @@ export default class Heatmap {
         for (const [idx, tick] of ticks.entries()) {
             const x = scale(tick);
 
-            container.append("line")
-                .attr("x1", x)
-                .attr("y1", ticksTop)
-                .attr("x2", x)
-                .attr("y2", ticksTop + LEGEND_TICK_LENGTH)
-                .attr("stroke", this.settings.labelColor);
+            shapes.push({
+                type: "line",
+                x1: x,
+                y1: ticksTop,
+                x2: x,
+                y2: ticksTop + LEGEND_TICK_LENGTH,
+                stroke: this.settings.labelColor
+            });
 
-            container.append("text")
-                .attr("x", x)
-                .attr("y", ticksTop + LEGEND_LABEL_SPACING)
-                .attr("font-size", legend.labelFontSize)
-                .attr("dominant-baseline", "hanging")
+            shapes.push({
+                type: "text",
+                x: x,
+                y: ticksTop + LEGEND_LABEL_SPACING,
+                fontSize: legend.labelFontSize,
                 // Anchor the outermost labels to the ends of the bar, otherwise they are clipped by the legend.
-                .attr("text-anchor", idx === 0 ? "start" : idx === ticks.length - 1 ? "end" : "middle")
-                .text(legend.tickFormat(tick));
+                anchor: idx === 0 ? "start" : idx === ticks.length - 1 ? "end" : "middle",
+                content: legend.tickFormat(tick)
+            });
+        }
+
+        return shapes;
+    }
+
+    /**
+     * Render the color bar that maps the colors used by the grid onto the values they represent. Does nothing when the
+     * legend is disabled.
+     */
+    private renderLegend() {
+        if (!this.legendElement) {
+            return;
+        }
+
+        const legend = this.settings.legend;
+        const height = this.legendHeight();
+
+        this.legendElement
+            .attr("width", this.settings.width)
+            .attr("height", height)
+            .attr("style", `display: block; width: ${this.settings.width}px; height: ${height}px`);
+
+        this.legendElement.selectAll("*").remove();
+
+        const container = this.legendElement
+            .append("g")
+            .attr("class", "legend")
+            .attr("transform", `translate(${legend.padding.left}, ${legend.padding.top})`)
+            .attr("font-family", LEGEND_FONT_FAMILY)
+            .attr("fill", this.settings.labelColor);
+
+        for (const shape of this.computeLegendShapes(this.legendBarWidth(this.settings.width))) {
+            if (shape.type === "rect") {
+                container.append("rect")
+                    .attr("x", shape.x)
+                    .attr("y", shape.y)
+                    .attr("width", shape.width)
+                    .attr("height", shape.height)
+                    .attr("fill", shape.fill)
+                    .attr("stroke", shape.stroke ?? null);
+            } else if (shape.type === "line") {
+                container.append("line")
+                    .attr("x1", shape.x1)
+                    .attr("y1", shape.y1)
+                    .attr("x2", shape.x2)
+                    .attr("y2", shape.y2)
+                    .attr("stroke", shape.stroke);
+            } else {
+                container.append("text")
+                    .attr("x", shape.x)
+                    .attr("y", shape.y)
+                    .attr("font-size", shape.fontSize)
+                    .attr("text-anchor", shape.anchor)
+                    .attr("dominant-baseline", "hanging")
+                    .text(shape.content);
+            }
         }
     }
 
     /**
+     * Convert the shapes of a legend into the corresponding SVG-elements.
+     *
+     * @param shapes Shapes that were computed by computeLegendShapes.
+     * @return A string with one SVG-element per given shape.
+     */
+    private legendShapesToSVG(shapes: LegendShape[]): string {
+        return shapes.map(shape => {
+            if (shape.type === "rect") {
+                const stroke = shape.stroke ? ` stroke="${shape.stroke}"` : "";
+
+                return `<rect x="${shape.x}" y="${shape.y}" width="${shape.width}" height="${shape.height}" fill="${shape.fill}"${stroke}></rect>`;
+            } else if (shape.type === "line") {
+                return `<line x1="${shape.x1}" y1="${shape.y1}" x2="${shape.x2}" y2="${shape.y2}" stroke="${shape.stroke}"></line>`;
+            } else {
+                return `<text x="${shape.x}" y="${shape.y}" font-size="${shape.fontSize}" text-anchor="${shape.anchor}" dominant-baseline="hanging">${shape.content}</text>`;
+            }
+        }).join("\n");
+    }
+
+    /**
      * Convert the heatmap to an SVG-string that can easily be downloaded as a valid SVG-file. Note that the current
-     * positioning and zooming level of the heatmap will not be taken into account (but clustering will!).
+     * positioning and zooming level of the heatmap will not be taken into account (but clustering will!). The legend
+     * is part of the produced SVG whenever it is enabled.
      *
      * Note that this function can take a while to compute for larger heatmaps. It is recommended to start this
      * function in a dedicated worker in order not to block the main JS thread.
@@ -552,9 +654,33 @@ export default class Heatmap {
             }
         }
 
+        // The legend is placed underneath the labels, at the size it also has on screen, and grows the exported image
+        // instead of overlapping it.
+        let legendContents = "";
+        let legendHeight = 0;
+
+        if (this.settings.enableLegend) {
+            const legend = this.settings.legend;
+
+            legendHeight = this.legendHeight();
+            const shapes = this.computeLegendShapes(this.legendBarWidth(maximumWidth));
+
+            legendContents = `
+                <g
+                    class="legend"
+                    transform="translate(${legend.padding.left}, ${maximumHeight + legend.padding.top})"
+                    font-family="${LEGEND_FONT_FAMILY}"
+                    fill="${this.settings.labelColor}"
+                >
+                    ${this.legendShapesToSVG(shapes)}
+                </g>
+            `;
+        }
+
         return `
-            <svg xmlns="http://www.w3.org/2000/svg" width="${Math.ceil(maximumWidth)}" height="${Math.ceil(maximumHeight)}">
+            <svg xmlns="http://www.w3.org/2000/svg" width="${Math.ceil(maximumWidth)}" height="${Math.ceil(maximumHeight + legendHeight)}">
                 ${svgContents}
+                ${legendContents}
             </svg>
         `;
     }

--- a/src/visualizations/heatmap/Heatmap.ts
+++ b/src/visualizations/heatmap/Heatmap.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import HeatmapSettings from "./HeatmapSettings";
+import HeatmapSettings, {HeatmapLegendSettings} from "./HeatmapSettings";
 import ClusterElement from "./cluster/ClusterElement";
 import TreeNode from "./cluster/TreeNode";
 import {Reorderer} from "./reorder/Reorderer";
@@ -16,6 +16,17 @@ type ViewPort = {
     xBottom: number,
     yBottom: number
 };
+
+const LEGEND_FONT_FAMILY = "'Helvetica Neue', Helvetica, Arial, sans-serif";
+
+// Vertical space (in pixels) between the legend's title and its color bar.
+const LEGEND_TITLE_SPACING = 6;
+
+// Vertical space (in pixels) between the legend's color bar and its tick labels. The tick marks are drawn in it.
+const LEGEND_LABEL_SPACING = 8;
+
+// Length (in pixels) of the tick marks underneath the legend's color bar.
+const LEGEND_TICK_LENGTH = 4;
 
 export default class Heatmap {
     private element: HTMLElement;
@@ -39,6 +50,8 @@ export default class Heatmap {
     private textHeight: number;
 
     private tooltip: d3.Selection<HTMLDivElement, unknown, HTMLElement, any> | null = null;
+
+    private legendElement: d3.Selection<SVGSVGElement, unknown, null, undefined> | null = null;
 
     private highlightedRow: number = -1;
     private highlightedColumn: number = -1;
@@ -96,7 +109,7 @@ export default class Heatmap {
             xTop: 0,
             yTop: 0,
             xBottom: this.settings.width,
-            yBottom: this.settings.height
+            yBottom: this.gridHeight
         }
 
         this.currentViewPort = this.originalViewPort;
@@ -111,8 +124,8 @@ export default class Heatmap {
         this.visElement = d3.select(this.element)
             .append("canvas")
             .attr("width", this.pixelRatio * this.settings.width)
-            .attr("height", this.pixelRatio * this.settings.height)
-            .attr("style", `width: ${this.settings.width}px; height: ${this.settings.height}px`)
+            .attr("height", this.pixelRatio * this.gridHeight)
+            .attr("style", this.canvasStyle())
             .on("mouseover", (event: MouseEvent) => this.tooltipMove(event))
             .on("mousemove", (event: MouseEvent) => this.tooltipMove(event))
             .on("mouseout", (event: MouseEvent) => this.tooltipMove(event))
@@ -121,7 +134,7 @@ export default class Heatmap {
         this.context.scale(this.pixelRatio, this.pixelRatio);
 
         const zoom = d3.zoom()
-            .extent([[0, 0], [this.settings.width, this.settings.height]])
+            .extent([[0, 0], [this.settings.width, this.gridHeight]])
             .scaleExtent([0.25, 12])
             .on("zoom", (event: d3.D3ZoomEvent<any, any>) => {
                 this.zoomed(event.transform);
@@ -130,6 +143,11 @@ export default class Heatmap {
         // @ts-expect-error
         this.visElement.call(zoom);
 
+        if (this.settings.enableLegend) {
+            this.legendElement = d3.select(this.element).append("svg");
+            this.renderLegend();
+        }
+
         this.computeClusterRoots();
 
         this.redraw();
@@ -137,7 +155,11 @@ export default class Heatmap {
 
     private fillOptions(options: any = undefined): HeatmapSettings {
         const output = new HeatmapSettings();
-        return Object.assign(output, options);
+        Object.assign(output, options);
+        // Object.assign is shallow, so a legend object that only mentions some of the settings would otherwise wipe
+        // out the defaults for all the others.
+        output.legend = Object.assign(new HeatmapLegendSettings(), options?.legend);
+        return output;
     }
 
     /**
@@ -288,19 +310,152 @@ export default class Heatmap {
         this.settings.width = newWidth;
         this.settings.height = newHeight;
 
-        this.visElement.attr("height", this.pixelRatio * newHeight);
+        this.visElement.attr("height", this.pixelRatio * this.gridHeight);
         this.visElement.attr("width", this.pixelRatio * newWidth);
-        this.visElement.attr("style", `width: ${this.settings.width}px; height: ${this.settings.height}px`);
+        this.visElement.attr("style", this.canvasStyle());
         this.context.scale(this.pixelRatio, this.pixelRatio);
 
         this.originalViewPort = {
             xTop: 0,
             yTop: 0,
             xBottom: newWidth,
-            yBottom: newHeight
+            yBottom: this.gridHeight
         }
 
+        this.renderLegend();
+
         this.zoomed(this.lastZoomStatus);
+    }
+
+    /**
+     * Height that's available to the heatmap grid itself. The legend is rendered underneath the grid and takes away
+     * part of the configured height, so that the visualization as a whole keeps the dimensions that were requested.
+     */
+    private get gridHeight(): number {
+        return this.settings.height - this.legendHeight();
+    }
+
+    private canvasStyle(): string {
+        // A canvas is an inline element, which would put the descender gap of a line box between it and the legend
+        // underneath it. Only opt out of that when there actually is a legend to keep away from.
+        const display = this.settings.enableLegend ? "display: block; " : "";
+        return `${display}width: ${this.settings.width}px; height: ${this.gridHeight}px`;
+    }
+
+    /**
+     * Amount of vertical space (in pixels) that's taken up by the legend, or 0 when the legend is disabled.
+     */
+    private legendHeight(): number {
+        if (!this.settings.enableLegend) {
+            return 0;
+        }
+
+        const legend = this.settings.legend;
+        const titleHeight = legend.title ? legend.titleFontSize + LEGEND_TITLE_SPACING : 0;
+
+        return legend.padding.top +
+            titleHeight +
+            legend.height +
+            LEGEND_LABEL_SPACING +
+            legend.labelFontSize +
+            legend.padding.bottom;
+    }
+
+    /**
+     * Render the color bar that maps the colors used by the grid onto the values they represent. Does nothing when the
+     * legend is disabled.
+     */
+    private renderLegend() {
+        if (!this.legendElement) {
+            return;
+        }
+
+        const legend = this.settings.legend;
+        const height = this.legendHeight();
+        const barWidth = Math.max(
+            1,
+            Math.min(legend.width, this.settings.width - legend.padding.left - legend.padding.right)
+        );
+
+        this.legendElement
+            .attr("width", this.settings.width)
+            .attr("height", height)
+            .attr("style", `display: block; width: ${this.settings.width}px; height: ${height}px`);
+
+        this.legendElement.selectAll("*").remove();
+
+        const container = this.legendElement
+            .append("g")
+            .attr("class", "legend")
+            .attr("transform", `translate(${legend.padding.left}, ${legend.padding.top})`)
+            .attr("font-family", LEGEND_FONT_FAMILY)
+            .attr("fill", this.settings.labelColor);
+
+        const barTop = legend.title ? legend.titleFontSize + LEGEND_TITLE_SPACING : 0;
+
+        if (legend.title) {
+            container.append("text")
+                .attr("x", 0)
+                .attr("y", 0)
+                .attr("font-size", legend.titleFontSize)
+                .attr("dominant-baseline", "hanging")
+                .text(legend.title);
+        }
+
+        // Render the palette that the grid itself uses instead of a smooth gradient, so that the legend also shows how
+        // coarse the color scale is when only a few color buckets are configured.
+        const palette = new Preprocessor().computeColorPalette(
+            this.settings.minColor,
+            this.settings.maxColor,
+            this.settings.colorBuckets
+        );
+
+        const bucketWidth = barWidth / palette.length;
+
+        for (const [idx, color] of palette.entries()) {
+            const x = idx * bucketWidth;
+
+            container.append("rect")
+                .attr("x", x)
+                .attr("y", barTop)
+                // Overlap the next bucket, since fractional widths otherwise leave hairlines between the buckets.
+                .attr("width", Math.min(bucketWidth + 1, barWidth - x))
+                .attr("height", legend.height)
+                .attr("fill", color);
+        }
+
+        // The color for the lowest value is a very light one by default, so outline the bar to keep it visible.
+        container.append("rect")
+            .attr("x", 0.5)
+            .attr("y", barTop + 0.5)
+            .attr("width", barWidth - 1)
+            .attr("height", legend.height - 1)
+            .attr("fill", "none")
+            .attr("stroke", "rgba(0, 0, 0, 0.2)");
+
+        const scale = d3.scaleLinear().domain([0, 1]).range([0, barWidth]);
+        const ticks = scale.ticks(legend.ticks);
+        const ticksTop = barTop + legend.height;
+
+        for (const [idx, tick] of ticks.entries()) {
+            const x = scale(tick);
+
+            container.append("line")
+                .attr("x1", x)
+                .attr("y1", ticksTop)
+                .attr("x2", x)
+                .attr("y2", ticksTop + LEGEND_TICK_LENGTH)
+                .attr("stroke", this.settings.labelColor);
+
+            container.append("text")
+                .attr("x", x)
+                .attr("y", ticksTop + LEGEND_LABEL_SPACING)
+                .attr("font-size", legend.labelFontSize)
+                .attr("dominant-baseline", "hanging")
+                // Anchor the outermost labels to the ends of the bar, otherwise they are clipped by the legend.
+                .attr("text-anchor", idx === 0 ? "start" : idx === ticks.length - 1 ? "end" : "middle")
+                .text(legend.tickFormat(tick));
+        }
     }
 
     /**
@@ -547,7 +702,7 @@ export default class Heatmap {
         const squareWidth = this.determineSquareWidth();
         const dendrogramWidth: number = this.determineDendrogramWidth();
 
-        this.context.clearRect(0, 0, this.settings.width, this.settings.height);
+        this.context.clearRect(0, 0, this.settings.width, this.gridHeight);
 
         for (const [color, values] of this.valuesPerColor) {
             this.context.beginPath();
@@ -575,7 +730,7 @@ export default class Heatmap {
                     continue;
                 }
 
-                if (yBottomCurrent < 0 || yTopCurrent > this.settings.height) {
+                if (yBottomCurrent < 0 || yTopCurrent > this.gridHeight) {
                     continue;
                 }
 

--- a/src/visualizations/heatmap/HeatmapSettings.ts
+++ b/src/visualizations/heatmap/HeatmapSettings.ts
@@ -1,4 +1,4 @@
-import Settings from "./../../Settings";
+import Settings, {VisualizationPadding} from "./../../Settings";
 import {HeatmapFeature} from "./HeatmapFeature";
 import {HeatmapValue} from "./HeatmapValue";
 import { Transition } from "./../../transition/Transition";
@@ -7,6 +7,57 @@ import UPGMAClusterer from "./cluster/UPGMAClusterer";
 import EuclidianDistanceMetric from "./metric/EuclidianDistanceMetric";
 import MoloReorderer from "./reorder/MoloReorderer";
 import {Reorderer} from "./reorder/Reorderer";
+
+export class HeatmapLegendSettings {
+    /**
+     * Padding around the legend area of the visualization.
+     */
+    padding: VisualizationPadding = {
+        top: 8,
+        right: 0,
+        bottom: 0,
+        left: 0
+    };
+
+    /**
+     * Title that's rendered above the color bar. No title is rendered when this string is empty.
+     */
+    title: string = "";
+
+    /**
+     * Size (in pixels) for the legend title.
+     */
+    titleFontSize: number = 14;
+
+    /**
+     * Width (in pixels) of the color bar. The bar is shrunk when less horizontal space is available.
+     */
+    width: number = 240;
+
+    /**
+     * Height (in pixels) of the color bar.
+     */
+    height: number = 12;
+
+    /**
+     * Size (in pixels) for the tick labels underneath the color bar.
+     */
+    labelFontSize: number = 12;
+
+    /**
+     * Amount of tick labels that should be rendered underneath the color bar. This value is a hint: the exact amount
+     * of ticks is chosen such that all of them are situated at a round value.
+     */
+    ticks: number = 5;
+
+    /**
+     * Converts a value of the color scale into the label that's shown for the corresponding tick.
+     *
+     * @param value A value from the interval [0, 1].
+     * @return The label that should be rendered for this tick.
+     */
+    tickFormat: (value: number) => string = (value: number) => value.toFixed(2);
+}
 
 export default class HeatmapSettings extends Settings {
     /**
@@ -118,6 +169,18 @@ export default class HeatmapSettings extends Settings {
      * Color of the lines used to construct a dendrogram (must be a valid HTML color string).
      */
     dendrogramColor: string = "#404040";
+
+    /**
+     * Should a legend that maps the used colors onto the values they represent be rendered underneath the grid? The
+     * legend takes up part of the configured height, so that the visualization as a whole keeps the requested
+     * dimensions.
+     */
+    enableLegend: boolean = false;
+
+    /**
+     * All settings that are directly related to the legend area of the visualization.
+     */
+    legend: HeatmapLegendSettings = new HeatmapLegendSettings();
 
     clusteringAlgorithm: Clusterer = new UPGMAClusterer(new EuclidianDistanceMetric());
 

--- a/src/visualizations/heatmap/Preprocessor.ts
+++ b/src/visualizations/heatmap/Preprocessor.ts
@@ -36,17 +36,15 @@ export default class Preprocessor {
         highColor: string,
         colorValues: number
     ): HeatmapValue[][] {
-        const interpolator = d3.interpolateLab(d3.lab(lowColor), d3.lab(highColor));
-
-        const x = d3.scaleLinear().domain([0, 1]).range([0, 1]);
-        const ticks = x.ticks(colorValues);
-        const quantizeScale = d3.scaleQuantize().domain([0, 1]).range(ticks);
+        const quantizeScale = d3.scaleQuantize<string>()
+            .domain([0, 1])
+            .range(this.computeColorPalette(lowColor, highColor, colorValues));
 
         return Object.entries(data).map(([rowIdx, row]) => Object.entries(row).map(([colIdx, value]) => {
             if (typeof value === "number") {
-                const quantizedValue = quantizeScale(value);
+                const color = quantizeScale(value);
 
-                if (quantizedValue === undefined) {
+                if (color === undefined) {
                     throw new Error("Invalid heatmap value given: " + value);
                 }
 
@@ -54,12 +52,29 @@ export default class Preprocessor {
                     value: value as number,
                     rowId: Number.parseInt(rowIdx),
                     columnId: Number.parseInt(colIdx),
-                    color: interpolator(quantizedValue)
+                    color
                 };
             } else {
                 return value;
             }
         }));
+    }
+
+    /**
+     * Compute the discrete list of colors that's used to render the grid, ordered from the color for the lowest value
+     * to the color for the highest value. Every color covers an equally large part of the [0, 1] value range.
+     *
+     * @param lowColor Color value that should be used for low values
+     * @param highColor Color value that should be used for high values
+     * @param colorValues How many discrete color values should be generated?
+     * @return An array of valid HTML-color values.
+     */
+    computeColorPalette(lowColor: string, highColor: string, colorValues: number): string[] {
+        const interpolator = d3.interpolateLab(d3.lab(lowColor), d3.lab(highColor));
+
+        const x = d3.scaleLinear().domain([0, 1]).range([0, 1]);
+
+        return x.ticks(colorValues).map(tick => interpolator(tick));
     }
 
     /**

--- a/src/visualizations/heatmap/__tests__/Heatmap.spec.ts
+++ b/src/visualizations/heatmap/__tests__/Heatmap.spec.ts
@@ -1,5 +1,6 @@
 import HeatmapSettings from "./../HeatmapSettings";
 import Heatmap from "./../Heatmap";
+import Preprocessor from "./../Preprocessor";
 import { JSDOM } from "jsdom";
 import { waitForCondition } from "./../../../test/TestUtils";
 import TestConsts from "./../../../test/TestConsts";
@@ -143,6 +144,118 @@ describe("Heatmap", () => {
 
         const image = await makeScreenshot(jsDom);
         expect(image).toMatchImageSnapshot(TestConsts.resolveImageSnapshotFolder(__filename));
+    });
+
+    function legendOf(jsDom: JSDOM): SVGSVGElement | null {
+        return jsDom.window.document.getElementById("visualization")!.getElementsByTagName("svg").item(0);
+    }
+
+    it("should not render a legend by default", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+        await createHeatmap(jsDom, new HeatmapSettings());
+
+        expect(legendOf(jsDom)).toBeNull();
+    });
+
+    it("should render a legend if requested", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const settings = new HeatmapSettings();
+        settings.enableLegend = true;
+        settings.legend.title = "Similarity";
+
+        await createHeatmap(jsDom, settings);
+
+        const legend = legendOf(jsDom)!;
+        expect(legend).not.toBeNull();
+
+        const labels = Array.from(legend.getElementsByTagName("text")).map(text => text.textContent);
+        expect(labels[0]).toBe("Similarity");
+        expect(labels[1]).toBe("0.00");
+        expect(labels[labels.length - 1]).toBe("1.00");
+    });
+
+    it("should fall back to the default legend settings for the ones that are not given", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        // A plain object is what a user of the library passes in, and it only mentions the settings it changes.
+        const settings = { enableLegend: true, legend: { title: "Similarity" } } as unknown as HeatmapSettings;
+
+        await createHeatmap(jsDom, settings);
+
+        const labels = Array.from(legendOf(jsDom)!.getElementsByTagName("text")).map(text => text.textContent);
+        expect(labels).toEqual(["Similarity", "0.00", "0.20", "0.40", "0.60", "0.80", "1.00"]);
+    });
+
+    it("should render the legend with the colors that are used by the grid", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const settings = new HeatmapSettings();
+        settings.enableLegend = true;
+        settings.minColor = "#ffebee";
+        settings.maxColor = "#c62828";
+        settings.colorBuckets = 5;
+
+        await createHeatmap(jsDom, settings);
+
+        const fills = Array.from(legendOf(jsDom)!.getElementsByTagName("rect"))
+            .map(rect => rect.getAttribute("fill"));
+
+        const palette = new Preprocessor().computeColorPalette("#ffebee", "#c62828", 5);
+
+        // The final rectangle is the outline that's drawn around the color bar.
+        expect(fills).toEqual([...palette, "none"]);
+    });
+
+    it("should reserve part of the configured height for the legend", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const settings = new HeatmapSettings();
+        settings.enableLegend = true;
+
+        await createHeatmap(jsDom, settings);
+
+        const canvas = jsDom.window.document.getElementsByTagName("canvas").item(0)!;
+
+        const canvasHeight = Number.parseFloat(canvas.style.height);
+        const legendHeight = Number.parseFloat(legendOf(jsDom)!.getAttribute("height")!);
+
+        expect(legendHeight).toBeGreaterThan(0);
+        expect(canvasHeight + legendHeight).toBe(400);
+    });
+
+    it("should keep the legend when the heatmap is resized, clustered or reset", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const settings = new HeatmapSettings();
+        settings.enableLegend = true;
+
+        const heatmap = await createHeatmap(jsDom, settings);
+
+        expect(legendOf(jsDom)!.getAttribute("width")).toBe("800");
+
+        heatmap.resize(600, 300);
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        expect(element.getElementsByTagName("svg").length).toBe(1);
+        expect(legendOf(jsDom)!.getAttribute("width")).toBe("600");
+
+        const canvas = jsDom.window.document.getElementsByTagName("canvas").item(0)!;
+        const firstDataUrl = canvas.toDataURL();
+
+        heatmap.cluster();
+        await waitForCondition(() => firstDataUrl !== canvas.toDataURL(), 2000, 500);
+
+        heatmap.reset();
+
+        expect(element.getElementsByTagName("svg").length).toBe(1);
+        expect(legendOf(jsDom)!.getElementsByTagName("rect").length).toBeGreaterThan(0);
     });
 
     afterAll(async() => {

--- a/src/visualizations/heatmap/__tests__/Heatmap.spec.ts
+++ b/src/visualizations/heatmap/__tests__/Heatmap.spec.ts
@@ -84,6 +84,16 @@ describe("Heatmap", () => {
 
     beforeAll(async() => {
         browser = await puppeteer.launch();
+
+        // jsdom does not implement OffscreenCanvas, which toSVG uses to measure the labels it produces.
+        (globalThis as any).OffscreenCanvas = class {
+            getContext() {
+                return {
+                    font: "",
+                    measureText: (text: string) => ({ width: text.length * 7 })
+                };
+            }
+        };
     });
 
     it("should produce the expected image with default settings ", async() => {
@@ -258,7 +268,77 @@ describe("Heatmap", () => {
         expect(legendOf(jsDom)!.getElementsByTagName("rect").length).toBeGreaterThan(0);
     });
 
+    it("should fall back to the default padding for the parts of it that are not given", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const settings = { enableLegend: true, legend: { padding: { top: 4 } } } as unknown as HeatmapSettings;
+
+        await createHeatmap(jsDom, settings);
+
+        const canvas = jsDom.window.document.getElementsByTagName("canvas").item(0)!;
+        const legendHeight = Number.parseFloat(legendOf(jsDom)!.getAttribute("height")!);
+
+        // The given padding, the color bar, the space for the tick marks and the tick labels.
+        expect(legendHeight).toBe(4 + 12 + 8 + 12);
+        expect(Number.parseFloat(canvas.style.height) + legendHeight).toBe(400);
+    });
+
+    it("should keep a usable grid when the configured height is smaller than the legend", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+        const element = jsDom.window.document.getElementById("visualization")!;
+
+        const settings = new HeatmapSettings();
+        settings.width = 800;
+        settings.height = 20;
+        settings.enableLegend = true;
+        settings.animationsEnabled = false;
+
+        const [items, rows, columns] = getClusterData();
+        const heatmap = new Heatmap(element, items, rows, columns, settings);
+
+        await waitForCondition(() => element.innerHTML.includes("canvas"), 2000, 500);
+
+        const canvas = element.getElementsByTagName("canvas").item(0)!;
+        expect(Number.parseFloat(canvas.getAttribute("height")!)).toBeGreaterThan(0);
+        expect(Number.parseFloat(canvas.style.height)).toBeGreaterThan(0);
+
+        heatmap.resize(800, 20);
+
+        expect(Number.parseFloat(canvas.getAttribute("height")!)).toBeGreaterThan(0);
+        expect(Number.parseFloat(canvas.style.height)).toBeGreaterThan(0);
+    });
+
+    it("should export the legend as part of the SVG when it is enabled", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const settings = new HeatmapSettings();
+        settings.enableLegend = true;
+        settings.legend.title = "Similarity";
+
+        const heatmap = await createHeatmap(jsDom, settings);
+
+        const svg = heatmap.toSVG();
+
+        expect(svg).toContain("class=\"legend\"");
+        expect(svg).toContain("Similarity");
+        expect(svg).toContain("1.00");
+    });
+
+    it("should not export a legend when it is disabled", async() => {
+        // This test requires the canvas package to be installed
+        const jsDom = createJSDom();
+
+        const heatmap = await createHeatmap(jsDom, new HeatmapSettings());
+
+        expect(heatmap.toSVG()).not.toContain("class=\"legend\"");
+    });
+
     afterAll(async() => {
         await browser.close();
+
+        delete (globalThis as any).OffscreenCanvas;
     });
 });

--- a/src/visualizations/heatmap/index.ts
+++ b/src/visualizations/heatmap/index.ts
@@ -1,9 +1,9 @@
 import Heatmap from "./Heatmap";
 import { HeatmapValue } from "./HeatmapValue";
-import HeatmapSettings from "./HeatmapSettings";
+import HeatmapSettings, { HeatmapLegendSettings } from "./HeatmapSettings";
 import { HeatmapFeature } from "./HeatmapFeature";
 
-export { Heatmap, HeatmapSettings }
+export { Heatmap, HeatmapSettings, HeatmapLegendSettings }
 export type { HeatmapValue, HeatmapFeature };
 export * from "./cluster/index";
 export * from "./metric/index";


### PR DESCRIPTION
The heatmap maps values onto a continuous color scale, but nothing said which color stood for which value. This adds an opt-in legend: a color bar underneath the grid, labelled with the values it covers.

The bar is drawn from the same discrete palette the grid uses (`minColor`, `maxColor` and `colorBuckets`), not from a hardcoded scale, so it also shows how coarse the scale is when few color buckets are configured. That palette is now computed once in `Preprocessor.computeColorPalette` and shared by the grid and the legend.

The legend takes its height out of the configured `height`, so a heatmap with a legend still measures exactly `width` by `height`. It is rendered as an SVG sibling of the canvas, kept in sync by `resize()`, and left untouched by `cluster()` and `reset()`. `toSVG()` includes it as well, so an exported heatmap keeps the scale that explains its colors. Both are built from one list of shapes computed by `computeLegendShapes`, so the live legend and the exported one cannot drift apart.

## New public API

All of it defaults to off, so existing heatmaps render exactly as before.

| Setting | Default | What it does |
| --- | --- | --- |
| `enableLegend` | `false` | Renders the legend underneath the grid, and in `toSVG()` output |
| `legend.title` | `""` | Title above the color bar. Nothing is rendered when empty |
| `legend.titleFontSize` | `14` | Title size in pixels |
| `legend.width` | `240` | Width of the color bar in pixels, shrunk when less space is available |
| `legend.height` | `12` | Height of the color bar in pixels |
| `legend.labelFontSize` | `12` | Tick label size in pixels |
| `legend.ticks` | `5` | Requested number of ticks, rounded to nice values |
| `legend.tickFormat` | `value => value.toFixed(2)` | Turns a value from `[0, 1]` into a tick label |
| `legend.padding` | `{ top: 8, right: 0, bottom: 0, left: 0 }` | Padding around the legend area |

`HeatmapLegendSettings` is exported alongside `HeatmapSettings`. A partial `legend` object keeps the defaults for the settings it does not mention, `padding` included.

### Heights that cannot fit the legend

When the configured `height` is smaller than the legend needs, the grid is clamped to a single pixel rather than the construction being refused. Heatmaps are routinely resized to whatever a container happens to measure, and a container that is briefly shorter than the legend should not throw and take the page down with it. The result is a visualization slightly taller than requested, which is the lesser problem, and no invalid height ever reaches the canvas.

## Manual testing

Run `npm run build`, serve the repository and open **`examples/heatmap-legend.html`**.

- The legend is visible under the grid: the title "Similarity", the blue color bar, and ticks from 0% to 100%.
- **Toggle legend** rebuilds the heatmap without a legend. The grid grows to fill the space the legend used.
- **Cluster** reorders the rows and columns. The legend stays put.
- **Resize** redraws at 1000 x 400. The legend stays under the grid and the whole thing is 400 pixels tall.
- **Export SVG** downloads `heatmap.svg`. Opening it shows the grid, the labels and the same legend underneath.

The other two heatmap examples are unchanged and must still look the same, since the legend is off by default.

<details>
<summary>What was verified</summary>

- `npm run lint`, `npm run typecheck` and `npm test` are all green. 77 tests, up from 65.
- The four existing heatmap image snapshots still match without being regenerated, which is the check that the default really is off.
- Ten new specs in `src/visualizations/heatmap/__tests__/Heatmap.spec.ts`: no legend by default, legend present when enabled, defaults kept for a partial `legend` object and for a partial `legend.padding`, bar colors equal to the grid palette, legend height subtracted from the grid height, a grid that stays valid when the height cannot fit the legend, the legend surviving `resize()`, `cluster()` and `reset()`, and `toSVG()` carrying the legend only when it is enabled.
- Each of the three review findings has a spec that fails on the previous commit with exactly the reported symptom (legend height `NaN`, canvas height `-20`, no legend group in the export) and passes on this one.
- `examples/heatmap-legend.html` loaded in puppeteer against a built `dist`: no console errors, canvas 540px plus legend 60px equals the configured 600px, after `resize(1000, 400)` canvas 340px plus legend 60px equals 400px, and toggling the legend off returns the canvas to the full 600px.
- The downloaded `heatmap.svg` was rendered in the browser: 1163 by 679 pixels, grid and labels unchanged, legend underneath them with the same title and ticks.
- In the browser, a heatmap built at a height of 20 pixels with `legend: { padding: { top: 4 } }` now gives a 1 pixel canvas and a 36 pixel legend, both on construction and after `resize(400, 20)`. Before, that was a 150 pixel canvas and a `NaN` legend.

</details>

Closes #119
