### PR TITLE
Stop the sunburst dropping a label when rerooting to an off-screen node

### DIFF
--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -433,8 +433,14 @@ export default class Sunburst {
         const newData = filteredData.filter((x: HRN<DataNode>) => !this.textData.includes(x));
         const data = this.textData.concat(...newData);
 
-        if (parentNode.parent) {
-            data.splice(data.indexOf(parentNode.parent), 1);
+        // The parent of the node that is being zoomed into sits in the ring around it, where there is no room for a
+        // label. It is only present when it was already on screen before this render: rerooting straight to a node
+        // that was not drawn yet reaches this with a parent that is absent, and splicing at the -1 that indexOf then
+        // returns would drop the last label of an unrelated node.
+        const parentIndex = parentNode.parent ? data.indexOf(parentNode.parent) : -1;
+
+        if (parentIndex !== -1) {
+            data.splice(parentIndex, 1);
         }
 
         // The font-size callback below has to be a `function` so that d3 binds

--- a/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
+++ b/src/visualizations/sunburst/__tests__/Sunburst.spec.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
 import puppeteer from "puppeteer";
 import taxonomyObject from "../../../test/resources/taxonomy.json";
+import NodeUtils from "./../../../utilities/NodeUtils";
 
 describe("Sunburst", () => {
     let browser: any;
@@ -124,6 +125,39 @@ describe("Sunburst", () => {
         await waitForCondition(() => element.innerHTML.includes("crumb"), 2000, 500);
 
         expect(nodeFromCallback!.name).toEqual("Eukaryota");
+    });
+
+    it("should keep every label when rerooting to a node that was not on screen", async() => {
+        const dom = createJSDom();
+        const element = dom.window.document.getElementById("visualization")!;
+
+        const settings = new SunburstSettings();
+        settings["animationDuration"] = 0;
+
+        const sunburst = new Sunburst(element, taxonomyObject, settings);
+        await waitForCondition(() => element.getElementsByTagName("text").length > 0, 3000, 500);
+
+        // Only `levels` rings are drawn, so a node below that depth has never had a label and its parent is therefore
+        // absent from the set the labels are joined to. That is the case in which the guard around the parent has to
+        // hold: the render still has to draw one label per node it is given.
+        const internals = sunburst as unknown as { data: any[], textData: any[], currentMaxLevel: number };
+        const target = internals.data.find(node => node.depth === 5 && node.data.name !== "empty")!;
+
+        expect(target).toBeDefined();
+
+        const onScreen = internals.textData;
+        sunburst.reroot(target.data.id);
+
+        await waitForCondition(() => false, 500, 100);
+
+        // The labels are joined to everything that was already on screen plus everything the new root brings in. The
+        // parent of the new root is in neither, so nothing may be dropped.
+        const expected = new Set(onScreen);
+        internals.data
+            .filter(node => NodeUtils.isParentOf(target, node, internals.currentMaxLevel))
+            .forEach(node => expected.add(node));
+
+        expect(element.getElementsByTagName("text").length).toEqual(expected.size);
     });
 
     afterAll(async() => {


### PR DESCRIPTION
Found while reviewing #208. Independent of it, and the two touch different parts of `renderText`.

## The bug

`renderText` drops the label of the node being zoomed into, because its parent sits in a ring with no room for one:

```ts
if (parentNode.parent) {
    data.splice(data.indexOf(parentNode.parent), 1);
}
```

The result of `indexOf` was never checked. A parent is only in `data` when it was already on screen before this render, so rerooting straight to a node that was not drawn yet reaches this with the parent absent, `indexOf` returns `-1`, and `splice(-1, 1)` removes the **last** entry rather than nothing. An unrelated node silently loses its label.

`levels` defaults to 4, so any `reroot()` to a node deeper than that hits it. Clicking through the rings does not, because there the parent is always already drawn, which is presumably why it survived.

Measured on the taxonomy fixture, rerooting straight to a depth 5 node:

```
before: 46 labels rendered
after:  47 labels rendered
```

## The fix

Look the parent up once and only splice when it was actually found.

## Manual testing

Open `examples/sunburst-taxonomy.html` and call `reroot()` from the console with the id of a node more than four levels deep. Before this change one label elsewhere in the ring is missing; after it every node that should be labelled is.

<details>
<summary>What I verified</summary>

- The new test fails against the unfixed code with `expected 46 to deeply equal 47` and passes with the fix.
- `lint`, `typecheck` and the full suite pass.
- The four existing sunburst image snapshots still match and were not regenerated, since the default view never reaches the broken branch.
- I confirmed the `-1` empirically before writing the fix, by instrumenting `renderText` and rerooting to three different off-screen nodes: `idx: -1` in all three, while clicking through the rings gave `idx: 0` every time.

</details>

Closes nothing; this bug had no issue.