### PR TITLE
Keep the barplot's nested settings defaults when only some are given

### DIFF
--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -1,4 +1,5 @@
-import {BarplotSettings} from "./BarplotSettings";
+import {BarplotSettings, BarplotChartSettings, BarplotLegendSettings} from "./BarplotSettings";
+import {VisualizationPadding} from "../../Settings";
 import * as d3 from "d3";
 import {Bar, BarItem} from "./Bar";
 import BarplotPreprocessor from "./BarplotPreprocessor";
@@ -34,7 +35,24 @@ export default class Barplot {
 
     private fillOptions(options: any = undefined): BarplotSettings {
         const output = new BarplotSettings();
-        return Object.assign(output, options);
+        Object.assign(output, options);
+
+        // Object.assign is shallow, so a caller that passes a plain object mentioning only the nested settings it
+        // wants to change would otherwise replace the whole group and leave the rest of it undefined. Rendering then
+        // fails on the first default it reads back.
+        output.chart = this.fillGroup(new BarplotChartSettings(), options?.chart);
+        output.legend = this.fillGroup(new BarplotLegendSettings(), options?.legend);
+
+        return output;
+    }
+
+    /**
+     * Copy the given overrides over a group of settings, treating the padding inside it the same way the group itself
+     * is treated: every corner that is not mentioned keeps its default.
+     */
+    private fillGroup<T extends { padding: VisualizationPadding }>(defaults: T, options: any): T {
+        const padding = Object.assign({}, defaults.padding, options?.padding);
+        return Object.assign(defaults, options, { padding });
     }
 
     private renderBarplot(): void {

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -173,21 +173,35 @@ describe("Barplot", () => {
     });
 
     it("should keep the defaults of the nested settings that are not given", async() => {
-        const jsDom = createTestDom();
-        const element = jsDom.window.document.getElementById("visualization")!;
-
-        // A plain object literal is what a user of the library passes in, and it only mentions what it changes.
-        const settings = {
-            legend: { title: "Taxa" },
-            chart: { padding: { left: 40 } }
+        // A plain object literal is what a user of the library passes in, and it only mentions what it changes. The
+        // cast is what that costs in TypeScript: the constructor asks for a complete BarplotSettings.
+        const overrides = {
+            chart: { padding: { left: 40 } },
+            legend: { titleFontSize: 40 }
         } as unknown as BarplotSettings;
 
-        const barplot = new Barplot(element, bars(), settings);
+        const withDefaults = createTestDom();
+        await createBarplot(withDefaults, new BarplotSettings());
 
-        await waitForCondition(() => element.getElementsByClassName("barplot-item").length > 0, 2000, 500);
+        const withOverrides = createTestDom();
+        await createBarplot(withOverrides, overrides);
 
-        expect(barplot).toBeDefined();
-        expect(element.getElementsByClassName("barplot-item").length).toBeGreaterThan(0);
+        const barLabel = (jsDom: JSDOM) =>
+            jsDom.window.document.querySelector(".barLabels text")!;
+        const legendTitle = (jsDom: JSDOM) => Array.from(
+            jsDom.window.document.getElementsByTagName("text")
+        ).find(text => text.textContent === "Legend")!;
+
+        // The override reaches the render.
+        expect(barLabel(withOverrides).getAttribute("x")).toEqual("40");
+        expect(legendTitle(withOverrides).getAttribute("font-size")).toEqual("40");
+
+        // Everything the override did not mention keeps its default. The vertical position of a bar label is built
+        // from chart.padding.top, which is only reachable if overriding `left` alone left the rest of the padding
+        // object intact.
+        expect(barLabel(withOverrides).getAttribute("y")).toEqual(barLabel(withDefaults).getAttribute("y"));
+        expect(barLabel(withDefaults).getAttribute("x")).toEqual("10");
+        expect(legendTitle(withDefaults).getAttribute("font-size")).toEqual("24");
     });
 
     afterAll(async() => {

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -172,6 +172,24 @@ describe("Barplot", () => {
         expect(element.className.split(/\s+/).filter((name: string) => name === "barplot")).toHaveLength(1);
     });
 
+    it("should keep the defaults of the nested settings that are not given", async() => {
+        const jsDom = createTestDom();
+        const element = jsDom.window.document.getElementById("visualization")!;
+
+        // A plain object literal is what a user of the library passes in, and it only mentions what it changes.
+        const settings = {
+            legend: { title: "Taxa" },
+            chart: { padding: { left: 40 } }
+        } as unknown as BarplotSettings;
+
+        const barplot = new Barplot(element, bars(), settings);
+
+        await waitForCondition(() => element.getElementsByClassName("barplot-item").length > 0, 2000, 500);
+
+        expect(barplot).toBeDefined();
+        expect(element.getElementsByClassName("barplot-item").length).toBeGreaterThan(0);
+    });
+
     afterAll(async() => {
         await browser.close();
     });


### PR DESCRIPTION
Found while reviewing #209, which fixes the same problem for the heatmap. This is the barplot half, on `main`, so the two do not depend on each other.

## The bug

`Barplot.fillOptions` merged the caller's options with one shallow `Object.assign`:

```ts
const output = new BarplotSettings();
return Object.assign(output, options);
```

`BarplotSettings` holds two nested groups, `chart: BarplotChartSettings` and `legend: BarplotLegendSettings`, and each holds a `padding` object. A shallow assign replaces a whole group rather than merging into it, so the natural way to call this crashes:

```js
new Barplot(element, data, { legend: { title: "Taxa" } });
// TypeError: Cannot read properties of undefined (reading "top")
```

`legend.padding` and every other legend default is gone, and rendering throws on the first one it reads. There is no way to change one nested setting without restating all of them.

## The fix

The two groups are merged individually, and `padding` inside them gets the same treatment, so overriding a single corner works:

```js
new Barplot(element, data, { chart: { padding: { left: 40 } } });
```

The barplot is the only visualization with this shape. The heatmap gets the same treatment in #209; `clusteringAlgorithm` and `reorderer` there are behaviour objects that are meant to be replaced wholesale, not merged, and the sunburst, treemap and treeview have no nested settings at all.

## Manual testing

`examples/barplot-taxonomy.html` still renders unchanged, since it passes no nested settings. To see the fix, add `legend: { title: "Taxa" }` to the settings object there. Before this change the page throws; after it the barplot renders with the title.

<details>
<summary>What I verified</summary>

- The new test throws `TypeError: Cannot read properties of undefined (reading "top")` against the unfixed code and passes with the fix.
- `lint`, `typecheck` and the full suite (66 tests) pass.
- The barplot image snapshot still matches and was not regenerated.
- I checked every settings class for the same shape before deciding the scope: only `BarplotSettings` has nested plain settings groups.

</details>

Closes nothing; this bug had no issue.