### PR TITLE
Accept a Uint8Array in the image snapshot matcher

### DIFF
--- a/src/test/__tests__/ImageSnapshotMatcher.spec.ts
+++ b/src/test/__tests__/ImageSnapshotMatcher.spec.ts
@@ -1,0 +1,34 @@
+import { afterAll, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const SNAPSHOT_FIXTURE = path.resolve(
+    __dirname,
+    "../../../test/snapshots/visualizations/barplot/__tests__/Barplot.spec_Barplot_>_should_render_a_barplot_with_default_settings.png"
+);
+
+describe("toMatchImageSnapshot", () => {
+    const customSnapshotsDir = fs.mkdtempSync(path.join(os.tmpdir(), "image-snapshot-matcher-"));
+
+    afterAll(() => {
+        fs.rmSync(customSnapshotsDir, { recursive: true, force: true });
+    });
+
+    // Puppeteer returns a Buffer on Node 24 but a plain Uint8Array on Node 25, so the
+    // matcher has to cope with a screenshot that is not a Buffer.
+    it("accepts a Uint8Array", () => {
+        const png = new Uint8Array(fs.readFileSync(SNAPSHOT_FIXTURE));
+        expect(Buffer.isBuffer(png)).toBe(false);
+
+        // The first call has no snapshot to compare against yet, so it writes one.
+        expect(png).toMatchImageSnapshot({ customSnapshotsDir });
+
+        const written = fs.readdirSync(customSnapshotsDir);
+        expect(written).toHaveLength(1);
+        expect(fs.readFileSync(path.join(customSnapshotsDir, written[0]))).toEqual(Buffer.from(png));
+
+        // The second call compares the same bytes against the snapshot just written.
+        expect(png).toMatchImageSnapshot({ customSnapshotsDir });
+    });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -10,6 +10,12 @@ expect.extend({
   toMatchImageSnapshot(received, snapshotSettings) {
     const { customSnapshotsDir, customDiffDir, failureThreshold = 0.1 } = snapshotSettings || {};
 
+    // Puppeteer returns a Buffer on Node 24 but a plain Uint8Array on Node 25, and
+    // pngjs only accepts a Buffer. Wrap the bytes without copying them.
+    const image = Buffer.isBuffer(received)
+      ? received
+      : Buffer.from(received.buffer, received.byteOffset, received.byteLength);
+
     if (!customSnapshotsDir) {
       throw new Error('customSnapshotsDir must be specified');
     }
@@ -34,7 +40,7 @@ expect.extend({
 
     // If snapshot doesn't exist, create it (first run)
     if (!fs.existsSync(snapshotPath)) {
-      fs.writeFileSync(snapshotPath, received);
+      fs.writeFileSync(snapshotPath, image);
       return {
         pass: true,
         message: () => `Snapshot created at ${snapshotPath}`
@@ -43,7 +49,7 @@ expect.extend({
 
     // Compare with existing snapshot
     const img1 = PNG.sync.read(fs.readFileSync(snapshotPath));
-    const img2 = PNG.sync.read(received);
+    const img2 = PNG.sync.read(image);
     const {width, height} = img1;
     const diff = new PNG({width, height});
 
@@ -57,7 +63,7 @@ expect.extend({
     if (!matches && customDiffDir) {
       const actualPath = path.join(customDiffDir, `actual_${snapshotName}`);
       const diffPath = path.join(customDiffDir, `diff_${snapshotName}`);
-      fs.writeFileSync(actualPath, received);
+      fs.writeFileSync(actualPath, image);
       fs.writeFileSync(diffPath, PNG.sync.write(diff));
     }
 


### PR DESCRIPTION
`page.screenshot()` returns a `Buffer` on Node 24, but a plain `Uint8Array` on Node 25. The matcher in `vitest.setup.ts` passed that value straight to `PNG.sync.read`, which only accepts a `Buffer`, so on Node 25 all 11 image snapshot tests fail with:

```
TypeError: data.readUInt32BE is not a function
 ❯ module.exports.Parser._parseChunkBegin node_modules/pngjs/lib/parser.js:57:21
 ❯ Object.toMatchImageSnapshot vitest.setup.ts:46:27
```

`.nvmrc` pins Node 24, so CI is green today and nothing is broken right now. This is about unblocking a future Node bump; no dependency and no `.nvmrc` change here.

## What changed

- `vitest.setup.ts` normalises the received value to a `Buffer` once, near the top. A `Buffer` is used as is; anything else is wrapped with `Buffer.from(value.buffer, value.byteOffset, value.byteLength)`, which is a view rather than a copy. That buffer is now used for the comparison and for both `writeFileSync` calls (first-run snapshot creation and the failure diff output).
- New `src/test/__tests__/ImageSnapshotMatcher.spec.ts` exercises the matcher directly with a `Uint8Array`, using a temporary snapshot directory so no committed snapshot is touched.

<details>
<summary>Verified</summary>

- Node 25.6.1 (Homebrew `node@25`) really does make Puppeteer 25 return a `Uint8Array`: a minimal `page.screenshot()` script printed `ctor: Uint8Array, Buffer.isBuffer: false` on 25.6.1 and `ctor: Buffer, Buffer.isBuffer: true` on 24.19.0, same byte length.
- `PNG.sync.read` on a committed snapshot PNG: works on a `Buffer`, throws the error above on a plain `Uint8Array`, works again on `Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength)`.
- The new test fails before the fix with that exact error and passes after.
- On Node 25.6.1, `Treemap.spec.ts` fails before the fix and passes after.
- On Node 24.19.0: `npm run lint`, `npm run typecheck` and `npm test` all pass, 15 files / 81 tests. `git status` shows no regenerated snapshots.
- Not verified: the full suite on Node 25. `canvas` in `node_modules` is built against the Node 24 ABI, so only the Puppeteer based specs were run there, not the whole run. Whether other parts of the repo need work for Node 25 is out of scope for this PR.

</details>
