### PR TITLE
Add tests for the color module

### DIFF
--- a/src/color/ColorUtils.ts
+++ b/src/color/ColorUtils.ts
@@ -5,11 +5,10 @@ export default class ColorUtils {
      * Returns the readable text color based on the brightness of a given background color.
      */
     public static getReadableColorFor(color: string) {
-        let textColor = "#000";
-        try {
-            textColor = ColorUtils.brightness(rgb(color)) < 125 ? "#eee" : "#000";
-        } catch { /* go on */ }
-        return textColor;
+        // d3 does not throw on a string it cannot read as a colour: it returns
+        // NaN channels, which makes the brightness NaN and the comparison
+        // below false. Unreadable input therefore falls back to dark text.
+        return ColorUtils.brightness(rgb(color)) < 125 ? "#eee" : "#000";
     }
 
     /*

--- a/src/color/__tests__/ColorPalette.spec.ts
+++ b/src/color/__tests__/ColorPalette.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { rgb } from "d3";
+import ColorPalette from "./../ColorPalette";
+
+const palettes: [string, string[]][] = [
+    ["DEFAULT_COLORS", ColorPalette.DEFAULT_COLORS],
+    ["FIXED_COLORS", ColorPalette.FIXED_COLORS],
+    ["MATERIAL_DESIGN_COLORS", ColorPalette.MATERIAL_DESIGN_COLORS]
+];
+
+describe.each(palettes)("ColorPalette.%s", (_name: string, palette: string[]) => {
+    it("is not empty", () => {
+        expect(palette.length).toBeGreaterThan(0);
+    });
+
+    /**
+     * The visualizations pass these strings straight to d3 and to the DOM. d3
+     * returns NaN channels instead of throwing for a string it cannot read, so
+     * an unparsable colour would silently render as black.
+     */
+    it("only contains colors that d3 can parse", () => {
+        for (const color of palette) {
+            const parsed = rgb(color);
+            expect(
+                [parsed.r, parsed.g, parsed.b].every((channel: number) => !Number.isNaN(channel)),
+                `${color} is not a color d3 can parse`
+            ).toBeTruthy();
+        }
+    });
+
+    /**
+     * The palettes are walked in order, one colour per node, so a duplicate
+     * would give two unrelated nodes the same colour before the palette is
+     * exhausted.
+     */
+    it("does not contain the same color twice", () => {
+        expect(new Set(palette).size).toEqual(palette.length);
+    });
+});
+
+describe("ColorPalette", () => {
+    it("keeps its palettes separate", () => {
+        expect(ColorPalette.DEFAULT_COLORS).not.toEqual(ColorPalette.FIXED_COLORS);
+        expect(ColorPalette.DEFAULT_COLORS).not.toEqual(ColorPalette.MATERIAL_DESIGN_COLORS);
+        expect(ColorPalette.FIXED_COLORS).not.toEqual(ColorPalette.MATERIAL_DESIGN_COLORS);
+    });
+});

--- a/src/color/__tests__/ColorUtils.spec.ts
+++ b/src/color/__tests__/ColorUtils.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import ColorUtils from "./../ColorUtils";
+import ColorPalette from "./../ColorPalette";
+
+describe("ColorUtils.brightness", () => {
+    it("returns 0 for black and 255 for white", () => {
+        expect(ColorUtils.brightness({ r: 0, g: 0, b: 0 })).toEqual(0);
+        expect(ColorUtils.brightness({ r: 255, g: 255, b: 255 })).toEqual(255);
+    });
+
+    /**
+     * The W3C formula (r * 0.299 + g * 0.587 + b * 0.114) weighs the channels
+     * by how bright the eye perceives them, so a fully saturated channel on its
+     * own is worth its coefficient times 255.
+     */
+    it("weighs a single channel by its W3C coefficient", () => {
+        expect(ColorUtils.brightness({ r: 255, g: 0, b: 0 })).toBeCloseTo(76.245);
+        expect(ColorUtils.brightness({ r: 0, g: 255, b: 0 })).toBeCloseTo(149.685);
+        expect(ColorUtils.brightness({ r: 0, g: 0, b: 255 })).toBeCloseTo(29.07);
+    });
+
+    it("counts green as the brightest channel and blue as the darkest", () => {
+        const red = ColorUtils.brightness({ r: 200, g: 0, b: 0 });
+        const green = ColorUtils.brightness({ r: 0, g: 200, b: 0 });
+        const blue = ColorUtils.brightness({ r: 0, g: 0, b: 200 });
+
+        expect(green).toBeGreaterThan(red);
+        expect(red).toBeGreaterThan(blue);
+    });
+
+    it("adds up the channels of a mixed color", () => {
+        expect(ColorUtils.brightness({ r: 138, g: 110, b: 158 })).toBeCloseTo(123.844);
+        expect(ColorUtils.brightness({ r: 46, g: 96, b: 147 })).toBeCloseTo(86.864);
+    });
+
+    it("returns the same value for every channel of a grey", () => {
+        expect(ColorUtils.brightness({ r: 125, g: 125, b: 125 })).toBeCloseTo(125);
+    });
+});
+
+describe("ColorUtils.getReadableColorFor", () => {
+    it("returns light text on a dark background", () => {
+        expect(ColorUtils.getReadableColorFor("#000000")).toEqual("#eee");
+        expect(ColorUtils.getReadableColorFor("#2e6093")).toEqual("#eee");
+        expect(ColorUtils.getReadableColorFor("rgb(0, 0, 0)")).toEqual("#eee");
+        expect(ColorUtils.getReadableColorFor("navy")).toEqual("#eee");
+    });
+
+    it("returns dark text on a light background", () => {
+        expect(ColorUtils.getReadableColorFor("#ffffff")).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor("#f9f0ab")).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor("rgb(255, 255, 255)")).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor("yellow")).toEqual("#000");
+    });
+
+    /**
+     * The visualizations hand this function whatever notation their palette or
+     * their colour scale produces: hex from the palettes, `rgb(...)` from d3
+     * colour objects that were turned into a string.
+     */
+    it("gives the same answer for every notation of the same color", () => {
+        const notations = ["#008000", "rgb(0, 128, 0)", "green", "hsl(120, 100%, 25.1%)"];
+
+        for (const notation of notations) {
+            expect(ColorUtils.getReadableColorFor(notation)).toEqual("#eee");
+        }
+    });
+
+    it("accepts the three digit form of a hex color", () => {
+        expect(ColorUtils.getReadableColorFor("#fff")).toEqual(ColorUtils.getReadableColorFor("#ffffff"));
+        expect(ColorUtils.getReadableColorFor("#000")).toEqual(ColorUtils.getReadableColorFor("#000000"));
+    });
+
+    it("switches from light to dark text at a brightness of 125", () => {
+        // The grey whose brightness is exactly 125 is on the dark text side,
+        // because the comparison is a strict "less than".
+        expect(ColorUtils.getReadableColorFor("rgb(125, 125, 125)")).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor("rgb(124, 124, 124)")).toEqual("#eee");
+    });
+
+    /**
+     * d3 does not throw on a colour it cannot parse, so this is the fallback of
+     * the brightness comparison rather than error handling. Pinned because the
+     * palettes are configurable, which means anything a caller puts in a
+     * settings object ends up here.
+     */
+    it("falls back to dark text for input that is not a color", () => {
+        expect(ColorUtils.getReadableColorFor("not-a-colour")).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor("")).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor(undefined as unknown as string)).toEqual("#000");
+        expect(ColorUtils.getReadableColorFor(null as unknown as string)).toEqual("#000");
+    });
+
+    it("returns one of its two text colors for every color of every palette", () => {
+        const palettes = [
+            ColorPalette.DEFAULT_COLORS,
+            ColorPalette.FIXED_COLORS,
+            ColorPalette.MATERIAL_DESIGN_COLORS
+        ];
+
+        for (const palette of palettes) {
+            for (const color of palette) {
+                expect(["#000", "#eee"]).toContain(ColorUtils.getReadableColorFor(color));
+            }
+        }
+    });
+});


### PR DESCRIPTION
`src/color/` is exported from `src/index.ts`, so `ColorPalette` and `ColorUtils` are public API, and it had no tests at all. `ColorUtils.getReadableColorFor` picks the text colour drawn on top of every coloured shape in the sunburst and the treemap, so a regression there makes labels unreadable across the library without breaking anything loudly enough to notice.

The tests (22 of them) cover:

* `ColorUtils.brightness`: the extremes, the W3C channel weights (a single saturated channel is worth its coefficient times 255), the channel ordering, and mixed colours against hand computed values.
* `ColorUtils.getReadableColorFor`: light text on dark backgrounds and dark text on light ones, in hex (three and six digit), `rgb()`, `hsl()` and named notation, the switch at a brightness of exactly 125, the fallback for input that is not a colour, and that every palette colour still produces one of the two text colours.
* `ColorPalette`: all three palettes are non-empty, contain only colours d3 can parse, and contain no duplicates.

## The `try/catch`

Removed. `getReadableColorFor` wrapped its body in `try { ... } catch { /* go on */ }`, but d3 never throws there: `rgb("not-a-colour")` returns an object with `NaN` channels, so `brightness` returns `NaN`, `NaN < 125` is `false`, and the function returns `"#000"`. The sane fallback for bad input was coming from the comparison, not from the error handling that appeared to provide it.

Both call sites (`Sunburst.color()` and `Treemap.colorScale(...).toString()`) can only pass a string, and no string makes d3 throw. The only values that reach the `catch` are a `Symbol` or an object with a throwing `toString`, neither of which is assignable to the declared `string` parameter. The behaviour is now pinned by a test and explained by a comment instead.

## Not changed

The palette and the 125 threshold are untouched.

<details>
<summary>Contrast measurements (observation only, no change requested)</summary>

6 of the 52 `DEFAULT_COLORS` fall below the WCAG AA 4.5:1 contrast ratio against the text colour this function picks for them:

| colour | text | ratio |
| --- | --- | --- |
| `#8a6e9e` | `#eee` | 3.77 |
| `#af643c` | `#eee` | 3.84 |
| `#9f6652` | `#eee` | 4.03 |
| `#8b6397` | `#eee` | 4.18 |
| `#72659d` | `#eee` | 4.45 |
| `#8f5c85` | `#eee` | 4.48 |

`FIXED_COLORS` has 11 of 60 below 4.5:1 (worst `#31a354` at 2.79) and `MATERIAL_DESIGN_COLORS` has 5 of 17 (worst `#ec407a` at 3.24). Fixing this means changing either the formula or the palettes, which changes how every visualization looks, so it is left as is.

</details>

No image snapshots were regenerated. This closes no issue.
