### PR TITLE
Give the barplot a resize method and a height that follows its contents

### DIFF
--- a/examples/barplot-resize.html
+++ b/examples/barplot-resize.html
@@ -25,13 +25,12 @@
 
 <main class="wrap example">
   <h1>Resizing a barplot</h1>
-  <p class="lede">The same two samples as the taxonomy example, but built with <code>width: 900</code>,
-    <code>height: 300</code>, <code>barHeight: 60</code>, <code>maxItems: 8</code> and
-    <code>legend.columns: 4</code>. <strong>Narrow</strong> and <strong>Wide</strong> call
-    <code>resize()</code> with a different width, which lays the bars, the axis and the legend columns out again
-    without rebuilding the barplot. <strong>Fit to stage</strong> passes the width the stage actually measures, which
-    is what a page that follows its container does. The stage scrolls sideways whenever the barplot ends up wider
-    than it is.</p>
+  <p class="lede">The same two samples as the taxonomy example, but built with <code>width: 700</code>,
+    <code>barHeight: 60</code>, <code>maxItems: 8</code> and <code>legend.columns: 4</code>. There is no height to
+    set: a barplot is as tall as the bars, the axis and the legend it holds. <strong>Narrow</strong> and
+    <strong>Wide</strong> call <code>resize()</code> with a different width, which lays the bars, the axis and the
+    legend columns out again without rebuilding the barplot. <strong>Fit to stage</strong> passes the width the stage
+    has room for, which is what a page that follows its container does.</p>
 
   <figure class="stage"><div id="barplot"></div></figure>
 
@@ -44,14 +43,17 @@
 <script type="module" data-source>
     import { Barplot } from "../dist/unipept-visualizations.js";
 
-    const height = 300;
     const element = document.getElementById("barplot");
     const stage = element.parentElement;
 
+    // The content box of the stage is the room the barplot has, and asking for it this way keeps the page from
+    // having to know anything about the padding the stylesheet gives the stage.
+    let roomInStage = 0;
+    new ResizeObserver(([entry]) => roomInStage = entry.contentBoxSize[0].inlineSize).observe(stage);
+
     d3.json("data/bars.json").then(data => {
         const barplot = new Barplot(element, data, {
-            width: 900,
-            height: height,
+            width: 700,
             barHeight: 60,
             maxItems: 8,
             legend: {
@@ -59,17 +61,9 @@
             }
         });
 
-        document.getElementById("narrow").addEventListener("click", () => barplot.resize(600, height));
-        document.getElementById("wide").addEventListener("click", () => barplot.resize(1200, height));
-        document.getElementById("fit").addEventListener("click", () => {
-            // The stage is what holds the barplot, so its padding is not room the barplot can use.
-            const style = getComputedStyle(stage);
-            const width = stage.clientWidth
-                - Number.parseFloat(style.paddingLeft)
-                - Number.parseFloat(style.paddingRight);
-
-            barplot.resize(Math.round(width), height);
-        });
+        document.getElementById("narrow").addEventListener("click", () => barplot.resize(500));
+        document.getElementById("wide").addEventListener("click", () => barplot.resize(900));
+        document.getElementById("fit").addEventListener("click", () => barplot.resize(Math.round(roomInStage)));
     });
 </script>
 

--- a/examples/barplot-resize.html
+++ b/examples/barplot-resize.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Resizing a barplot &middot; Unipept Visualizations</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Ccircle cx=%278%27 cy=%278%27 r=%277%27 fill=%27%23a0248c%27/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="examples.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="wrap">
+    <a class="crumb-home" href="index.html">Examples</a>
+    <span class="crumb-sep">/</span>
+    <span class="crumb">Barplot &middot; Resize</span>
+    <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Barplot">Docs &rarr;</a></span>
+  </div>
+</header>
+
+<main class="wrap example">
+  <h1>Resizing a barplot</h1>
+  <p class="lede">The same two samples as the taxonomy example, but built with <code>width: 900</code>,
+    <code>height: 300</code>, <code>barHeight: 60</code>, <code>maxItems: 8</code> and
+    <code>legend.columns: 4</code>. <strong>Narrow</strong> and <strong>Wide</strong> call
+    <code>resize()</code> with a different width, which lays the bars, the axis and the legend columns out again
+    without rebuilding the barplot. <strong>Fit to stage</strong> passes the width the stage actually measures, which
+    is what a page that follows its container does. The stage scrolls sideways whenever the barplot ends up wider
+    than it is.</p>
+
+  <figure class="stage"><div id="barplot"></div></figure>
+
+  <div class="controls">
+    <button id="narrow" type="button">Narrow</button>
+    <button id="wide" type="button">Wide</button>
+    <button id="fit" type="button">Fit to stage</button>
+  </div>
+
+<script type="module" data-source>
+    import { Barplot } from "../dist/unipept-visualizations.js";
+
+    const height = 300;
+    const element = document.getElementById("barplot");
+    const stage = element.parentElement;
+
+    d3.json("data/bars.json").then(data => {
+        const barplot = new Barplot(element, data, {
+            width: 900,
+            height: height,
+            barHeight: 60,
+            maxItems: 8,
+            legend: {
+                columns: 4
+            }
+        });
+
+        document.getElementById("narrow").addEventListener("click", () => barplot.resize(600, height));
+        document.getElementById("wide").addEventListener("click", () => barplot.resize(1200, height));
+        document.getElementById("fit").addEventListener("click", () => {
+            // The stage is what holds the barplot, so its padding is not room the barplot can use.
+            const style = getComputedStyle(stage);
+            const width = stage.clientWidth
+                - Number.parseFloat(style.paddingLeft)
+                - Number.parseFloat(style.paddingRight);
+
+            barplot.resize(Math.round(width), height);
+        });
+    });
+</script>
+
+  <section class="source">
+    <p class="section-label">Source</p>
+    <pre><code data-source-target></code></pre>
+  </section>
+</main>
+
+<script type="module" src="examples.js"></script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -95,6 +95,7 @@
           <p class="links-label">Open an example</p>
           <ul class="links">
             <li><a href="barplot-taxonomy.html">Taxonomy</a></li>
+            <li><a href="barplot-resize.html">Resize</a></li>
           </ul>
           <span class="docs"><a href="https://github.com/unipept/unipept-visualizations/wiki/Barplot">Docs &rarr;</a></span>
         </div>

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -6,6 +6,21 @@ import BarplotPreprocessor from "./BarplotPreprocessor";
 import Tooltip from "../../utilities/Tooltip";
 import StyleUtilities from "../../utilities/StyleUtilities";
 
+/**
+ * Height (in pixels) of the x-axis: its tick marks, their labels and the title underneath them.
+ */
+const X_AXIS_HEIGHT = 40;
+
+/**
+ * Vertical space (in pixels) between the bottom of the bars and the x-axis underneath them.
+ */
+const AXIS_PADDING_TOP = 5;
+
+/**
+ * Vertical space (in pixels) between the title of the legend and its first row of entries.
+ */
+const LEGEND_TITLE_PADDING_BOTTOM = 10;
+
 export default class Barplot {
     private readonly settings: BarplotSettings;
     private readonly data: Bar[];
@@ -34,18 +49,22 @@ export default class Barplot {
     }
 
     /**
-     * Resize the visualization to the given dimensions and render it again with the data and the options that were
-     * passed in the constructor.
+     * Resize the visualization to the given width and render it again with the data and the options that were passed
+     * in the constructor.
      *
-     * Note that only the width changes the layout of the plot: the height of the plot follows from the height of a bar
-     * and the number of bars, so the height given here only sets how much room the visualization takes up in the page.
+     * There is no height to give: a barplot is as tall as the bars, the axis and the legend it holds, so its height
+     * follows from the data and from settings such as `barHeight`, and it is recomputed here along with the layout.
      *
      * @param newWidth New total width (in pixels) of the visualization.
-     * @param newHeight New total height (in pixels) of the visualization.
      */
-    public resize(newWidth: number, newHeight: number) {
+    public resize(newWidth: number) {
+        // The render throws away the node the pointer is over, and a node that is removed never gets a mouseout of
+        // its own, so without this the tooltip is left on screen describing a bar that is no longer there.
+        if (this.settings.enableTooltips && this.tooltip) {
+            this.tooltip.hide();
+        }
+
         this.settings.width = newWidth;
-        this.settings.height = newHeight;
 
         this.renderBarplot();
     }
@@ -72,6 +91,55 @@ export default class Barplot {
         return Object.assign(defaults, options, { padding });
     }
 
+    /**
+     * Total height (in pixels) of the visualization, which is the height of what it holds: the bars, the axis
+     * underneath them and the legend.
+     *
+     * There is no height setting to honour instead. How tall a barplot is follows from the number of bars it is given
+     * and from `barHeight`, so a configured height could only cut the visualization off (the SVG hides its overflow)
+     * or leave empty space below it.
+     */
+    private get contentHeight(): number {
+        const plotHeight = this.settings.chart.padding.top +
+            this.plotAreaHeight +
+            AXIS_PADDING_TOP +
+            X_AXIS_HEIGHT +
+            this.settings.chart.padding.bottom;
+
+        // A horizontal legend is placed beside the plot and so starts at the top of the visualization, while a
+        // vertical one is placed underneath the bars and the axis.
+        const legendBottom = this.settings.orientation === "horizontal"
+            ? this.legendHeight
+            : this.plotAreaHeight + X_AXIS_HEIGHT + this.legendHeight;
+
+        return Math.max(plotHeight, legendBottom);
+    }
+
+    /**
+     * Height (in pixels) of the area the bars themselves take up.
+     */
+    private get plotAreaHeight(): number {
+        return this.settings.barHeight * this.data.length;
+    }
+
+    /**
+     * Height (in pixels) of the legend, from the top of its padding down to the bottom of it.
+     */
+    private get legendHeight(): number {
+        const legend = this.settings.legend;
+
+        const entries = new Set(this.data.flatMap(bar => bar.items.map(item => item.label))).size;
+        const rows = Math.ceil(entries / legend.columns);
+        const rowHeight = Math.max(legend.symbolSize, legend.labelFontSize);
+
+        return legend.padding.top +
+            legend.titleFontSize +
+            LEGEND_TITLE_PADDING_BOTTOM +
+            rows * rowHeight +
+            Math.max(rows - 1, 0) * legend.rowSpacing +
+            legend.padding.bottom;
+    }
+
     private renderBarplot(): void {
         // Constructing a barplot on an element that already holds one has to replace it, not add a second one next to
         // it.
@@ -81,9 +149,9 @@ export default class Barplot {
             .append("svg")
             .attr("version", "1.1")
             .attr("xmlns", "http://www.w3.org/2000/svg")
-            .attr("viewBox", `0 0 ${this.settings.width} ${this.settings.height}`)
+            .attr("viewBox", `0 0 ${this.settings.width} ${this.contentHeight}`)
             .attr("width", this.settings.width)
-            .attr("height", this.settings.height)
+            .attr("height", this.contentHeight)
             .attr("overflow", "hidden")
             .style("font-family", this.settings.font);
 
@@ -94,9 +162,6 @@ export default class Barplot {
         // Plot settings
         // Padding for the actual plot area
         const plotPadding = this.settings.chart.padding;
-
-        // Height of each bar in the barplot
-        const barHeight = this.settings.barHeight;
 
         const isHorizontal = this.settings.orientation == "horizontal";
 
@@ -117,17 +182,8 @@ export default class Barplot {
 
         const legendColumns = this.settings.legend.columns;
 
-        // Padding below the title of the legend
-        const legendTitlePaddingBottom = 10;
-
         // Horizontal padding between legend colored box and legend label
         const legendSymbolPaddingRight = 10;
-
-        /**
-         * Axis settings
-         */
-        // Height of the x-axis bar and it's labels
-        const xAxisHeight: number = 40;
 
         let plotAreaWidth: number;
         let legendContentStartLeft: number;
@@ -148,8 +204,7 @@ export default class Barplot {
             legendEntryWidth = legendWidth - legendPadding.left - legendPadding.right;
         } else {
             plotAreaWidth = this.settings.width - plotPadding.left - plotPadding.right;
-            const plotAreaHeight = barHeight * this.data.length;
-            legendContentStartTop = plotAreaHeight + legendPadding.top + xAxisHeight;
+            legendContentStartTop = this.plotAreaHeight + legendPadding.top + X_AXIS_HEIGHT;
             legendContentStartLeft = legendPadding.left;
             legendEntryHeight = Math.max(legendSymbolSize, legendLabelFontSize);
             legendAreaWidth = this.settings.width - legendPadding.left - legendPadding.right;
@@ -184,7 +239,7 @@ export default class Barplot {
 
         const yScale = d3.scaleBand()
             .domain(this.data.map((_, i) => i.toString()))
-            .range([0, barHeight * this.data.length])
+            .range([0, this.plotAreaHeight])
             .paddingInner(0.1)
             .paddingOuter(0);
 
@@ -331,14 +386,14 @@ export default class Barplot {
 
         // Add x-axis
         svgGElement.append("g")
-            .attr("transform", `translate(${plotPadding.left + barLabelWidth + barLabelPaddingRight}, ${plotPadding.top + barHeight * this.data.length + 5})`)
+            .attr("transform", `translate(${plotPadding.left + barLabelWidth + barLabelPaddingRight}, ${plotPadding.top + this.plotAreaHeight + AXIS_PADDING_TOP})`)
             .call(d3.axisBottom(xScale))
             .attr("font-size", "12px") // Increase tick label size
             .append("text")
             .attr("font-family", font)
             .attr("fill", "black")
             .attr("x", barWidth / 2)
-            .attr("y", xAxisHeight)
+            .attr("y", X_AXIS_HEIGHT)
             .attr("text-anchor", "middle")
             .attr("font-size", 14)
             .text(this.settings.displayMode === "relative" ? "Percentage" : "Count");
@@ -352,7 +407,7 @@ export default class Barplot {
             .join("g")
             .classed("legend-item", true)
             .attr("data-legend-entry", (d) => d)
-            .attr("transform", (_, i) => `translate(${(i % legendColumns) * legendEntryWidth + Math.max((i % legendColumns) - 1, 0) * legendColumnSpacing}, ${Math.floor(i / legendColumns) * (legendEntryHeight + legendRowSpacing) + legendTitleFontSize + legendTitlePaddingBottom + legendContentStartTop})`);
+            .attr("transform", (_, i) => `translate(${(i % legendColumns) * legendEntryWidth + Math.max((i % legendColumns) - 1, 0) * legendColumnSpacing}, ${Math.floor(i / legendColumns) * (legendEntryHeight + legendRowSpacing) + legendTitleFontSize + LEGEND_TITLE_PADDING_BOTTOM + legendContentStartTop})`);
 
         // Legend title
         svgGElement.append("text")

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -33,6 +33,23 @@ export default class Barplot {
         this.renderBarplot();
     }
 
+    /**
+     * Resize the visualization to the given dimensions and render it again with the data and the options that were
+     * passed in the constructor.
+     *
+     * Note that only the width changes the layout of the plot: the height of the plot follows from the height of a bar
+     * and the number of bars, so the height given here only sets how much room the visualization takes up in the page.
+     *
+     * @param newWidth New total width (in pixels) of the visualization.
+     * @param newHeight New total height (in pixels) of the visualization.
+     */
+    public resize(newWidth: number, newHeight: number) {
+        this.settings.width = newWidth;
+        this.settings.height = newHeight;
+
+        this.renderBarplot();
+    }
+
     private fillOptions(options: any = undefined): BarplotSettings {
         const output = new BarplotSettings();
         Object.assign(output, options);

--- a/src/visualizations/barplot/BarplotSettings.ts
+++ b/src/visualizations/barplot/BarplotSettings.ts
@@ -64,6 +64,12 @@ export class BarplotLegendSettings {
 
 export class BarplotSettings extends Settings {
     /**
+     * Ignored by the barplot, which is as tall as the bars, the axis and the legend it holds. Its height therefore
+     * follows from the data and from `barHeight`, rather than being something that can be set.
+     */
+    height: number = 800;
+
+    /**
      * In horizontal mode, the legend will be displayed to the right of the barplot area. In vertical mode, the legend
      * will be placed below the actual plot.
      */

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -56,6 +56,17 @@ describe("Barplot", () => {
             .map(text => text.textContent ?? "");
     }
 
+    /**
+     * Right edge of the widest bar, which is where the plot area ends and thus follows the configured width.
+     */
+    function barExtent(jsDom: JSDOM): number {
+        const rects = Array.from(jsDom.window.document.querySelectorAll(".barplot-item rect"));
+
+        return Math.max(...rects.map(rect =>
+            Number.parseFloat(rect.getAttribute("x")!) + Number.parseFloat(rect.getAttribute("width")!)
+        ));
+    }
+
     beforeAll(async() => {
         browser = await puppeteer.launch();
     });
@@ -202,6 +213,64 @@ describe("Barplot", () => {
         expect(barLabel(withOverrides).getAttribute("y")).toEqual(barLabel(withDefaults).getAttribute("y"));
         expect(barLabel(withDefaults).getAttribute("x")).toEqual("10");
         expect(legendTitle(withDefaults).getAttribute("font-size")).toEqual("24");
+    });
+
+    it("should lay the plot out against the new size when it is resized", async() => {
+        const jsDom = createTestDom();
+        const barplot = await createBarplot(jsDom, new BarplotSettings());
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const svg = () => element.getElementsByTagName("svg").item(0)!;
+
+        // The plot area is what is left of the width after the chart padding, the bar labels and the space behind
+        // them: 800 - 10 - 10 - 150 - 10.
+        expect(barExtent(jsDom)).toBe(790);
+
+        barplot.resize(1200, 400);
+
+        expect(svg().getAttribute("width")).toBe("1200");
+        expect(svg().getAttribute("height")).toBe("400");
+        expect(svg().getAttribute("viewBox")).toBe("0 0 1200 400");
+        expect(barExtent(jsDom)).toBe(1190);
+    });
+
+    it("should still render the same bars after a resize", async() => {
+        const jsDom = createTestDom();
+        const barplot = await createBarplot(jsDom, new BarplotSettings());
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const barLabels = () => Array.from(element.querySelectorAll(".barLabels text")).map(text => text.textContent);
+        const items = () => element.getElementsByClassName("barplot-item").length;
+
+        const labelsBefore = barLabels();
+        const itemsBefore = items();
+
+        barplot.resize(1200, 400);
+
+        expect(barLabels()).toEqual(labelsBefore);
+        expect(items()).toEqual(itemsBefore);
+        expect(new Set(legendLabels(jsDom))).toEqual(new Set(["Bacteria", "Eukaryota", "Archaea"]));
+
+        const labels = valueLabels(jsDom).filter(label => label.length > 0);
+        expect(labels.length).toBeGreaterThan(0);
+        expect(labels.every(label => label.endsWith("%"))).toBe(true);
+    });
+
+    it("should replace the previous render when resized instead of adding a second one", async() => {
+        const jsDom = createTestDom();
+        const barplot = await createBarplot(jsDom, new BarplotSettings());
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const children = element.children.length;
+        const styles = jsDom.window.document.head.getElementsByTagName("style").length;
+
+        barplot.resize(1200, 400);
+        barplot.resize(900, 500);
+
+        expect(element.getElementsByTagName("svg").length).toBe(1);
+        expect(element.children.length).toEqual(children);
+        expect(jsDom.window.document.head.getElementsByTagName("style").length).toEqual(styles);
+        expect(element.className.split(/\s+/).filter((name: string) => name === "barplot")).toHaveLength(1);
     });
 
     afterAll(async() => {

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -46,6 +46,19 @@ describe("Barplot", () => {
         return barplot;
     }
 
+    /**
+     * Builds a barplot without forcing a size onto the settings first, which is what the tests about the size need.
+     */
+    async function buildBarplot(jsDom: JSDOM, settings: BarplotSettings, data: Bar[] = bars()): Promise<HTMLElement> {
+        const element = jsDom.window.document.getElementById("visualization")!;
+
+        new Barplot(element, data, settings);
+
+        await waitForCondition(() => element.getElementsByTagName("svg").length > 0, 2000, 500);
+
+        return element;
+    }
+
     function legendLabels(jsDom: JSDOM): string[] {
         return Array.from(jsDom.window.document.querySelectorAll(".legend-item"))
             .map(entry => entry.getAttribute("data-legend-entry") ?? "");
@@ -215,7 +228,7 @@ describe("Barplot", () => {
         expect(legendTitle(withDefaults).getAttribute("font-size")).toEqual("24");
     });
 
-    it("should lay the plot out against the new size when it is resized", async() => {
+    it("should lay the plot out against the new width when it is resized", async() => {
         const jsDom = createTestDom();
         const barplot = await createBarplot(jsDom, new BarplotSettings());
 
@@ -226,12 +239,16 @@ describe("Barplot", () => {
         // them: 800 - 10 - 10 - 150 - 10.
         expect(barExtent(jsDom)).toBe(790);
 
-        barplot.resize(1200, 400);
+        const height = svg().getAttribute("height");
+
+        barplot.resize(1200);
 
         expect(svg().getAttribute("width")).toBe("1200");
-        expect(svg().getAttribute("height")).toBe("400");
-        expect(svg().getAttribute("viewBox")).toBe("0 0 1200 400");
+        expect(svg().getAttribute("viewBox")).toBe(`0 0 1200 ${height}`);
         expect(barExtent(jsDom)).toBe(1190);
+
+        // Nothing about the height of the visualization is a function of its width.
+        expect(svg().getAttribute("height")).toBe(height);
     });
 
     it("should still render the same bars after a resize", async() => {
@@ -245,7 +262,7 @@ describe("Barplot", () => {
         const labelsBefore = barLabels();
         const itemsBefore = items();
 
-        barplot.resize(1200, 400);
+        barplot.resize(1200);
 
         expect(barLabels()).toEqual(labelsBefore);
         expect(items()).toEqual(itemsBefore);
@@ -264,13 +281,117 @@ describe("Barplot", () => {
         const children = element.children.length;
         const styles = jsDom.window.document.head.getElementsByTagName("style").length;
 
-        barplot.resize(1200, 400);
-        barplot.resize(900, 500);
+        barplot.resize(1200);
+        barplot.resize(900);
 
         expect(element.getElementsByTagName("svg").length).toBe(1);
         expect(element.children.length).toEqual(children);
         expect(jsDom.window.document.head.getElementsByTagName("style").length).toEqual(styles);
         expect(element.className.split(/\s+/).filter((name: string) => name === "barplot")).toHaveLength(1);
+    });
+
+    it("should be as tall as the bars, the axis and the legend it holds", async() => {
+        const jsDom = createTestDom();
+        await createBarplot(jsDom, new BarplotSettings());
+
+        const height = (dom: JSDOM) =>
+            dom.window.document.getElementsByTagName("svg").item(0)!.getAttribute("height");
+
+        // Two bars of 75, the 40 the axis takes up, and a legend of one row: its padding (10 and 10), its title
+        // (24) and the 10 underneath that, and a row of 16.
+        expect(height(jsDom)).toBe("260");
+
+        const taller = createTestDom();
+        await createBarplot(taller, new BarplotSettings(), [...bars(), {
+            label: "Sample 3",
+            items: [{ label: "Bacteria", counts: 4 }, { label: "Eukaryota", counts: 4 }]
+        }]);
+
+        // One more bar is one more barHeight, and nothing else.
+        expect(height(taller)).toBe("335");
+    });
+
+    it("should ignore the height in the settings", async() => {
+        const heightOf = async(height: number) => {
+            const settings = new BarplotSettings();
+            settings.height = height;
+
+            const element = await buildBarplot(createTestDom(), settings);
+
+            return element.getElementsByTagName("svg").item(0)!.getAttribute("height");
+        };
+
+        // A barplot is as tall as its contents whatever the settings ask for, so both of these are the 260 the two
+        // bars above come to.
+        expect(await heightOf(100)).toBe("260");
+        expect(await heightOf(5000)).toBe("260");
+    });
+
+    it("should draw every bar it is given, however many that is", async() => {
+        const jsDom = createTestDom();
+        const many = Array.from({ length: 20 }, (_, i) => ({
+            label: `Sample ${i}`,
+            items: [
+                { label: "Bacteria", counts: 10 + i },
+                { label: "Eukaryota", counts: 5 },
+                { label: "Archaea", counts: 1 }
+            ]
+        }));
+
+        await createBarplot(jsDom, new BarplotSettings(), many);
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const svg = element.getElementsByTagName("svg").item(0)!;
+        const height = Number.parseFloat(svg.getAttribute("height")!);
+
+        expect(jsDom.window.document.querySelectorAll(".barLabels text")).toHaveLength(20);
+
+        // The SVG hides its overflow, so a bar that reaches past the bottom of it is a bar that is cut off. Twenty
+        // bars of 75 are 1500 pixels, well past the 800 the height used to be fixed at.
+        const rects = Array.from(jsDom.window.document.querySelectorAll(".barplot-item rect"));
+        const lowest = Math.max(...rects.map(rect =>
+            Number.parseFloat(rect.getAttribute("y")!) + Number.parseFloat(rect.getAttribute("height")!)
+        ));
+
+        expect(height).toBeGreaterThan(1500);
+        expect(lowest).toBeLessThanOrEqual(height);
+    });
+
+    it("should render a resize exactly like a barplot that was built at that width", async() => {
+        const resized = createTestDom();
+        const barplot = await createBarplot(resized, new BarplotSettings());
+        barplot.resize(640);
+
+        const settings = new BarplotSettings();
+        settings.width = 640;
+
+        const element = await buildBarplot(createTestDom(), settings);
+
+        expect(resized.window.document.getElementById("visualization")!.innerHTML)
+            .toEqual(element.innerHTML);
+    });
+
+    it("should hide a tooltip that is showing when it is resized", async() => {
+        const jsDom = createTestDom();
+        const barplot = await createBarplot(jsDom, new BarplotSettings());
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+
+        element.getElementsByClassName("barplot-item").item(0)!.dispatchEvent(new jsDom.window.MouseEvent("mouseover", {
+            view: jsDom.window as unknown as Window,
+            bubbles: true,
+            clientX: 100,
+            clientY: 50
+        }));
+
+        const tooltip = () => jsDom.window.document.body.querySelector(".tip") as HTMLElement;
+        expect(tooltip().style.visibility).toEqual("visible");
+
+        // The node the pointer is over is thrown away by the render, so it never gets a mouseout of its own. Without
+        // help, the tooltip is left showing what it said about a bar that is no longer there.
+        barplot.resize(1200);
+
+        expect(tooltip().style.visibility).toEqual("hidden");
     });
 
     afterAll(async() => {


### PR DESCRIPTION
## The gap

The barplot is the only visualization with no public methods at all. The heatmap has `cluster()`, `reset()`, `resize()` and `toSVG()`, the treemap has `reroot()`, `reset()` and `resize()`, the sunburst has `reroot()` and `reset()`, and the treeview has `reset()`. The barplot has nothing, so a barplot cannot be resized once it has been constructed. The only way to change one is to construct a new barplot over the top of it, which does work since #207, but it throws the preprocessed data away and rebuilds everything for what is a layout change.

Working on that turned up a second problem, in how the barplot handles its height. Both are in here.

## The new API

```ts
public resize(newWidth: number): void
```

Sets `width` in the settings of this barplot to the given value and renders the barplot again, in place, from the data and the options that were passed to the constructor. The element the barplot lives in keeps holding exactly one barplot: the render empties it first, the same way the constructor does.

Semantics worth stating for a published library:

* There is no height argument, because the barplot no longer has a configurable height. See the next section.
* The data is not touched. `maxItems` binning and the conversion to percentages for `displayMode: "relative"` both happen once, in the constructor, and a resize reuses that result rather than recomputing it. The bars and the legend after a resize are the same bars and the same legend, laid out against the new width.
* The settings are updated, not just the render, so a later resize and anything else that reads `settings.width` sees the new width. This matches `Heatmap.resize` and `Treemap.resize`.
* A resize produces exactly what constructing at that width produces. This is checked as a test, and separately in a browser, in both cases by comparing the rendered markup character for character.
* Everything set up outside the render survives it. The stylesheet is rewritten in place rather than added again (`StyleUtilities.applyStyle`), the tooltip is shared per container and creates its element on first use, so a tooltip that lived inside the barplot's own element is made again when it is needed, and the mouse handlers are attached to the freshly rendered nodes. No duplicate SVG, stylesheet or tooltip element is left behind, however often a barplot is resized.
* A tooltip that is showing is hidden before the render. See "Tooltips" below.

## The height now follows the content

`settings.height` was never a size. The height of a barplot is decided by `barHeight` and the number of bars, and the SVG carries `overflow="hidden"`, so a configured height could only leave blank space below the plot or cut the plot off. Both happen in practice:

* `examples/barplot-taxonomy.html`, which passes no settings at all, rendered an SVG 800 pixels tall whose content ended at 378. More than half of the library's own default barplot was blank space.
* `barHeight` defaults to 75, so about ten bars fill the default 800 and everything past that was silently clipped.

The SVG `height` and `viewBox` are now derived from the same layout the render is built from: the chart padding, `barHeight` times the number of bars, the x-axis, and the legend, which sits below the plot in `vertical` orientation and beside it in `horizontal`.

**`settings.height` is no longer read by the barplot.** It is inherited from the shared `Settings` base class so it cannot be removed, and it is documented as ignored in `BarplotSettings`. That is why `resize` takes a width only: an argument that is ignored is worse than no argument, the same reasoning as for leaving `reset()` out below.

The numbers, measured in a browser:

| | before | after |
| --- | --- | --- |
| `barplot-taxonomy.html`, default settings | SVG 800 tall, content ends at 378, 422 wasted | SVG 386 tall, content ends at 378 |
| 20 bars at the default `barHeight` | SVG 800 tall, 1500 pixels of bars, the rest clipped | SVG 1610 tall, all 20 bars drawn in full |

**This is visible to anyone embedding the barplot.** The element a barplot renders into is now as tall as its content instead of a fixed 800, so an embedding page that relied on the old height, or that sized a container around it, will see its layout shift. Worth a minor version and a note in the release, especially since the Unipept frontend depends on `^2.2.5` and would pick a 2.3.0 up without opting in.

## Tooltips

A review comment on this PR pointed out that `resize()` removes the node the pointer is over without that node ever getting a `mouseout`, which leaves the tooltip on screen showing what it said about a bar that is no longer there. Reproduced and fixed: `resize()` hides the tooltip before rendering again.

**The same thing happens without `resize`, and this PR does not fix that.** Emptying the host element is what strands the tooltip, and every visualization empties its host element in its constructor, so constructing any visualization over an element whose tooltip is showing leaves that tooltip visible with stale content. Verified for a barplot built over a barplot, a treemap built over a treemap, and a treemap built over a barplot, which leaves the barplot's tooltip text on screen. That is pre-existing behaviour in already merged code rather than something this PR introduces, so it is left alone here and reported separately. A central fix is not obviously a one liner either: `Tooltip` is shared per container and several visualizations can share one element, so a visualization cannot tell whether the tooltip that is currently showing is one it put there.

## No `reset()`

`reset()` is not part of this. On the other visualizations it undoes state that accumulated after construction: the heatmap undoes clustering and the current viewport, the treemap and the sunburst go back to the top of the tree. The barplot has no such state. There is no navigation, no clustering and no zoom, and the hover highlight already clears itself on mouse out. A `reset()` here could only re-render into a result identical to what is already on the screen, so it would be a method that does nothing a caller can observe. It is left out rather than added for symmetry.

## Manual testing

New example page `examples/barplot-resize.html`, linked from the barplot card in `examples/index.html`. Run `npm run build`, serve `examples/` and open it.

* **Narrow** calls `resize(500)`. The bars, the axis and the legend columns get narrower, and the legend labels truncate further.
* **Wide** calls `resize(900)`. Everything gets wider and the legend labels lose their ellipsis.
* **Fit to stage** resizes to the width the stage has room for, which is the case this method exists for. The page gets that width from a `ResizeObserver` on the stage rather than from its padding, so it makes no assumption about `examples.css`.
* Hovering a bar segment after clicking through all three still shows the tooltip and still dims the other segments and the matching legend entry.
* `examples/barplot-taxonomy.html` is worth opening as well, since it is where the wasted vertical space is most obvious.

## Tests

Eight tests in `src/visualizations/barplot/__tests__/Barplot.spec.ts`, in the style of the specs that were already there: the geometry follows the new width, the bars and the legend are still correct afterwards, repeated resizes leave no second SVG or stylesheet behind, a resize renders exactly what constructing at that width renders, the height is the height of the content, `settings.height` is ignored, twenty bars are all drawn without being cut off, and a tooltip that is showing is hidden by a resize.

This closes no issue.

<details>
<summary>What was verified</summary>

* `npm run lint`, `npm run typecheck` and `npm test` are all clean. 107 tests pass, up from 99.
* Each group of tests was run against the code without the change it covers. The three `resize` tests fail there with `TypeError: barplot.resize is not a function`, and the tooltip test fails with `expected 'visible' to deeply equal 'hidden'`.
* The geometry assertions are real rather than smoke tests: the right edge of the widest bar is 790 at a width of 800 and 1190 at a width of 1200, and the SVG of the two bar test fixture is 260 tall, which is the two bars, the axis and the one legend row added up.
* **The existing barplot image snapshot was not regenerated, because it does not change.** It was expected to, but the test fixture is two bars and three legend entries, so its content already ended at 260 of the 800 the SVG used to be, and the 540 pixels that went away were blank white against a white page. Instrumenting the matcher to print the pixel count gives 0 mismatched pixels out of 1000x1000. The snapshot was opened and looked at: it shows a correctly laid out two bar barplot with its axis and legend, nothing clipped. No other snapshot was touched, and no screenshot or thumbnail image was regenerated.
* The previously clipped case was checked in a browser as well as in a test: 20 bars at the default `barHeight` give an SVG 1610 tall whose lowest bar ends at 1509 and whose ink ends at 1602, with all 20 bar labels present. A screenshot of it was inspected, and every bar, the axis and the legend are drawn in full.
* The resize and construct equivalence was rechecked in a browser after every change in this PR: a barplot built at 700 and resized to 500 has markup identical, character for character, to one built at 500 (25201 characters).
* The example page was loaded in puppeteer over a local static server after `npm run build`, each of the three buttons was clicked and the screenshots inspected. The SVG went 700 to 500 to 900 to 1010 wide with the `viewBox` following, the height stayed at 272 throughout, and none of the four widths overflows the stage. The bar count, the legend entry count and the bar labels were identical throughout, and the element held one SVG and the document one barplot stylesheet and one tooltip element. No console or page errors.

</details>
