### PR TITLE
Expose the element a visualization renders into

### DIFF
--- a/src/visualizations/__tests__/HostElement.spec.ts
+++ b/src/visualizations/__tests__/HostElement.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { createTestDom } from "../../test/TestDom";
+import { waitForCondition } from "../../test/TestUtils";
+import Barplot from "../barplot/Barplot";
+import { BarplotSettings } from "../barplot/BarplotSettings";
+import Sunburst from "../sunburst/Sunburst";
+import SunburstSettings from "../sunburst/SunburstSettings";
+import Treemap from "../treemap/Treemap";
+import TreemapSettings from "../treemap/TreemapSettings";
+import Treeview from "../treeview/Treeview";
+import Heatmap from "../heatmap/Heatmap";
+import HeatmapSettings from "../heatmap/HeatmapSettings";
+import TreeviewSettings from "../treeview/TreeviewSettings";
+import taxonomyObject from "../../test/resources/taxonomy.json";
+
+/**
+ * Applications embedding this library need to reach the rendered output in order to export it. Until this was exposed
+ * the only way in was the private field, which the Unipept frontend reads behind a `@ts-ignore`.
+ */
+describe("the element a visualization renders into", () => {
+    it("gives access to the rendered output", async() => {
+        const jsDom = createTestDom();
+        const host = jsDom.window.document.getElementById("visualization")!;
+
+        const settings = new TreeviewSettings();
+        settings.width = 600;
+        settings.height = 600;
+
+        const treeview = new Treeview(host, taxonomyObject, settings);
+        await waitForCondition(() => host.getElementsByClassName("node").length > 0, 3000, 100);
+
+        expect(treeview.element).toBe(host);
+        expect(treeview.element.querySelector(":scope > svg")).not.toBeNull();
+    });
+
+    it("is the element that was passed to every visualization's constructor", () => {
+        const hosts: HTMLElement[] = [];
+
+        const host = (): HTMLElement => {
+            const element = createTestDom().window.document.getElementById("visualization")!;
+            hosts.push(element);
+            return element;
+        };
+
+        const barplotSettings = new BarplotSettings();
+        barplotSettings.width = 600;
+
+        const sunburstSettings = new SunburstSettings();
+        sunburstSettings.animationDuration = 0;
+
+        const treemapSettings = new TreemapSettings();
+        treemapSettings.width = 400;
+        treemapSettings.height = 300;
+
+        const treeviewSettings = new TreeviewSettings();
+        treeviewSettings.width = 600;
+        treeviewSettings.height = 600;
+
+        const heatmapSettings = new HeatmapSettings();
+        heatmapSettings.animationsEnabled = false;
+        heatmapSettings.width = 400;
+        heatmapSettings.height = 300;
+
+        const elements = [
+            new Barplot(host(), [{ label: "S1", items: [{ label: "a", counts: 3 }, { label: "b", counts: 5 }] }], barplotSettings).element,
+            new Sunburst(host(), taxonomyObject, sunburstSettings).element,
+            new Treemap(host(), taxonomyObject, treemapSettings).element,
+            new Treeview(host(), taxonomyObject, treeviewSettings).element,
+            // The heatmap takes its data as a matrix with labels rather than a tree. It needs the canvas package,
+            // like the other heatmap specs.
+            new Heatmap(host(), [[0.1, 0.9], [0.5, 0.2]], ["r1", "r2"], ["c1", "c2"], heatmapSettings).element
+        ];
+
+        expect(elements).toEqual(hosts);
+    });
+});

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -13,7 +13,9 @@ export default class Barplot {
     private tooltip!: Tooltip;
     
     constructor(
-        private readonly element: HTMLElement,
+        // Public so that an embedding application can reach the rendered output, for example to export the SVG
+        // that was drawn into it.
+        public readonly element: HTMLElement,
         data: Bar[],
         options: BarplotSettings = new BarplotSettings()
     ) {

--- a/src/visualizations/heatmap/Heatmap.ts
+++ b/src/visualizations/heatmap/Heatmap.ts
@@ -47,7 +47,11 @@ type LegendShape =
     { type: "text", x: number, y: number, fontSize: number, anchor: string, content: string };
 
 export default class Heatmap {
-    private element: HTMLElement;
+    /**
+     * The element this visualization renders into, as it was passed to the constructor. Exposed so that an embedding
+     * application can reach the rendered output, for example to export the SVG that was drawn into it.
+     */
+    public readonly element: HTMLElement;
     private settings: HeatmapSettings;
 
     private rows: HeatmapFeature[];

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -61,7 +61,9 @@ export default class Sunburst {
     private previousMaxLevel: number = this.currentMaxLevel;
 
     constructor(
-        private readonly element: HTMLElement,
+        // Public so that an embedding application can reach the rendered output, for example to export the SVG
+        // that was drawn into it.
+        public readonly element: HTMLElement,
         data: DataNodeLike,
         options: SunburstSettings = new SunburstSettings()
     ) {

--- a/src/visualizations/treemap/Treemap.ts
+++ b/src/visualizations/treemap/Treemap.ts
@@ -28,7 +28,9 @@ export default class Treemap {
     private nodeId: number = 0;
 
     constructor(
-        private element: HTMLElement,
+        // Public so that an embedding application can reach the rendered output, for example to export the SVG
+        // that was drawn into it.
+        public readonly element: HTMLElement,
         data: DataNodeLike,
         options: TreemapSettings = new TreemapSettings()
     ) {

--- a/src/visualizations/treeview/Treeview.ts
+++ b/src/visualizations/treeview/Treeview.ts
@@ -35,7 +35,9 @@ export default class Treeview {
     private svg: any;
 
     constructor(
-        private readonly element: HTMLElement,
+        // Public so that an embedding application can reach the rendered output, for example to export the SVG
+        // that was drawn into it.
+        public readonly element: HTMLElement,
         data: DataNodeLike,
         options: TreeviewSettings = new TreeviewSettings()
     ) {


### PR DESCRIPTION
## Why

The Unipept frontend needs the rendered SVG to power its download button, and the only way in was the private field. `unipept/src/components/results/taxonomic/Treeview.vue:49` reads it like this:

```js
// @ts-ignore We're accessing the private property element of UnipeptTreeview here, but this is the only way
// we get access to a properly initialized SVG... We might have to consider adding a getter for this element
// in a future version of the Unipept Visualizations library.
const svg = computed(() => visualizationObject.value?.element.querySelector(":scope > svg"))
```

So the field is already load-bearing for a downstream consumer: renaming it silently breaks their download, and TypeScript cannot warn them because the access is behind a `@ts-ignore`. This makes the arrangement explicit.

## What changed

`element` goes from `private` to `public readonly` on all five visualizations. `readonly` grants read access only, so nothing outside can swap the host element out from under a rendered visualization.

No behaviour changes and nothing is renamed, so this is additive for every existing consumer.

## Manual testing

Nothing visual changes. To see the API, construct any visualization and read `.element`.

<details>
<summary>What I verified</summary>

- Confirmed nothing reassigns `this.element` outside a constructor before marking it `readonly`; the only assignment is `Heatmap.ts:106`, inside the constructor, which `readonly` permits.
- The new spec fails against the unchanged code with `TS2341: Property 'element' is private` for all five classes, and passes after.
- `lint`, `typecheck` and the full suite (123 tests) pass.
- No image snapshot changed.

</details>

This closes no issue.