### PR TITLE
Hide the tooltip when a visualization clears its host element, and fix the barplot highlight

### DIFF
--- a/src/utilities/HostElement.ts
+++ b/src/utilities/HostElement.ts
@@ -1,0 +1,21 @@
+import Tooltip from "./Tooltip";
+
+export default class HostElement {
+    /**
+     * Empties the element a visualization renders in, so that constructing a visualization on an element that already
+     * holds one replaces it instead of adding a second one next to it.
+     *
+     * The tooltip is taken down along with the contents. Removing the node the pointer is over does not fire a
+     * mouseout on it, so the handler that would normally hide the tooltip never runs and it is left on screen
+     * describing something that no longer exists. Clearing and hiding therefore belong together, which is why every
+     * visualization goes through here rather than emptying its element itself.
+     *
+     * @param element The element the visualization is rendered in.
+     * @param tooltipContainer The tooltip container of the visualization, as configured in its settings.
+     */
+    public static clear(element: HTMLElement, tooltipContainer: HTMLElement | string | null = null): void {
+        Tooltip.hideFor(element, tooltipContainer);
+
+        element.innerHTML = "";
+    }
+}

--- a/src/utilities/HostUtilities.ts
+++ b/src/utilities/HostUtilities.ts
@@ -1,6 +1,6 @@
 import Tooltip from "./Tooltip";
 
-export default class HostElement {
+export default class HostUtilities {
     /**
      * Empties the element a visualization renders in, so that constructing a visualization on an element that already
      * holds one replaces it instead of adding a second one next to it.

--- a/src/utilities/Tooltip.ts
+++ b/src/utilities/Tooltip.ts
@@ -60,6 +60,28 @@ export default class Tooltip {
     }
 
     /**
+     * Hides the tooltip that belongs to the given container, if one was ever made for it.
+     *
+     * Static because the visualization that has to take a tooltip down is not necessarily the one that put it up: the
+     * tooltip is shared per container, and a visualization that runs with tooltips disabled holds no instance at all
+     * while a tooltip of a sibling may well be on screen. Hiding whatever the container has costs that sibling
+     * nothing more than a tooltip that returns on the next mouse move.
+     *
+     * Nothing is created here. A container that never showed a tooltip has none to hide, and an unresolvable
+     * container selector is left to whoever asks for a tooltip to actually show.
+     *
+     * @param reference An element of the visualization the tooltip belongs to, as in {@link create}.
+     * @param container The container the tooltip was created in, or a selector for it.
+     */
+    public static hideFor(reference: HTMLElement, container: HTMLElement | string | null = null): void {
+        const parent = Tooltip.findContainer(reference, container);
+
+        if (parent) {
+            Tooltip.instances.get(parent)?.hide();
+        }
+    }
+
+    /**
      * Fills the tooltip with the given content, moves it to the mouse cursor and shows it.
      */
     public show(event: MouseEvent, content: string): void {
@@ -163,6 +185,16 @@ export default class Tooltip {
     }
 
     private static resolveContainer(reference: HTMLElement, container: HTMLElement | string | null): HTMLElement {
+        const resolved = Tooltip.findContainer(reference, container);
+
+        if (!resolved) {
+            throw new Error(`No element matches the tooltip container selector "${container}".`);
+        }
+
+        return resolved;
+    }
+
+    private static findContainer(reference: HTMLElement, container: HTMLElement | string | null): HTMLElement | null {
         if (!container) {
             return reference.ownerDocument.body;
         }
@@ -171,13 +203,7 @@ export default class Tooltip {
             return container;
         }
 
-        const resolved = reference.ownerDocument.querySelector<HTMLElement>(container);
-
-        if (!resolved) {
-            throw new Error(`No element matches the tooltip container selector "${container}".`);
-        }
-
-        return resolved;
+        return reference.ownerDocument.querySelector<HTMLElement>(container);
     }
 
     /**

--- a/src/utilities/__tests__/Tooltip.spec.ts
+++ b/src/utilities/__tests__/Tooltip.spec.ts
@@ -146,6 +146,24 @@ describe("Tooltip", () => {
         expect((tooltipElements(dom)[0] as HTMLElement).style.visibility).toEqual("hidden");
     });
 
+    it("should hide the tooltip of a container without being handed its instance", () => {
+        const dom = createTestDom();
+
+        Tooltip.create(reference(dom)).show(mouseEvent(100, 50), "<div>Bacteria</div>");
+        Tooltip.hideFor(reference(dom));
+
+        expect((tooltipElements(dom)[0] as HTMLElement).style.visibility).toEqual("hidden");
+    });
+
+    it("should not create a tooltip for a container that never showed one", () => {
+        const dom = createTestDom();
+
+        Tooltip.hideFor(reference(dom));
+        Tooltip.hideFor(reference(dom), "#nothing");
+
+        expect(tooltipElements(dom)).toHaveLength(0);
+    });
+
     it("should leave the styling of the tooltip to the application", () => {
         const dom = createTestDom();
         const style = dom.window.document.createElement("style");

--- a/src/visualizations/__tests__/StaleTooltip.spec.ts
+++ b/src/visualizations/__tests__/StaleTooltip.spec.ts
@@ -1,0 +1,128 @@
+import { createTestDom } from "./../../test/TestDom";
+import { waitForCondition } from "./../../test/TestUtils";
+import Barplot from "./../barplot/Barplot";
+import { Bar } from "./../barplot/Bar";
+import { BarplotSettings } from "./../barplot/BarplotSettings";
+import Treemap from "./../treemap/Treemap";
+import TreemapSettings from "./../treemap/TreemapSettings";
+import taxonomyObject from "./../../test/resources/taxonomy.json";
+import { JSDOM } from "jsdom";
+import { describe, it, expect } from "vitest";
+
+/**
+ * A visualization empties the element it renders in, which takes away the node the pointer is over without that node
+ * ever getting a mouseout. These tests cover what that leaves behind: a tooltip that is still on screen, describing
+ * something that is no longer there.
+ */
+describe("Stale tooltips", () => {
+    function bars(): Bar[] {
+        return [
+            {
+                label: "Sample 1",
+                items: [
+                    { label: "Bacteria", counts: 10 },
+                    { label: "Eukaryota", counts: 5 }
+                ]
+            }
+        ];
+    }
+
+    function barplotSettings(): BarplotSettings {
+        const settings = new BarplotSettings();
+        settings.width = 800;
+        settings.height = 800;
+        return settings;
+    }
+
+    function treemapSettings(): TreemapSettings {
+        const settings = new TreemapSettings();
+        settings.width = 800;
+        settings.height = 800;
+        return settings;
+    }
+
+    function host(dom: JSDOM): HTMLElement {
+        return dom.window.document.getElementById("visualization")!;
+    }
+
+    function tooltip(dom: JSDOM): HTMLElement {
+        return dom.window.document.querySelector<HTMLElement>(".tip[data-unipept-tooltip]")!;
+    }
+
+    function hover(dom: JSDOM, target: Element): void {
+        target.dispatchEvent(new dom.window.MouseEvent("mouseover", { clientX: 10, clientY: 10 }));
+    }
+
+    async function renderBarplot(dom: JSDOM, settings: BarplotSettings = barplotSettings()): Promise<void> {
+        const element = host(dom);
+        new Barplot(element, bars(), settings);
+        await waitForCondition(() => element.getElementsByTagName("svg").length > 0, 2000, 500);
+    }
+
+    async function renderTreemap(dom: JSDOM, settings: TreemapSettings = treemapSettings()): Promise<void> {
+        const element = host(dom);
+        new Treemap(element, taxonomyObject, settings);
+        await waitForCondition(() => element.getElementsByClassName("node").length > 0, 2000, 500);
+    }
+
+    function hoverBarplotItem(dom: JSDOM): void {
+        hover(dom, host(dom).querySelector(".barplot-item")!);
+    }
+
+    function hoverTreemapNode(dom: JSDOM): void {
+        hover(dom, host(dom).querySelector(".node")!);
+    }
+
+    it("should hide the tooltip when a barplot is constructed over a barplot", async() => {
+        const dom = createTestDom();
+        await renderBarplot(dom);
+
+        hoverBarplotItem(dom);
+        expect(tooltip(dom).style.visibility).toEqual("visible");
+
+        await renderBarplot(dom);
+
+        expect(tooltip(dom).style.visibility).toEqual("hidden");
+    });
+
+    it("should hide the tooltip when a treemap is constructed over a treemap", async() => {
+        const dom = createTestDom();
+        await renderTreemap(dom);
+
+        hoverTreemapNode(dom);
+        expect(tooltip(dom).style.visibility).toEqual("visible");
+
+        await renderTreemap(dom);
+
+        expect(tooltip(dom).style.visibility).toEqual("hidden");
+    });
+
+    it("should hide the tooltip of another visualization when a treemap is constructed over a barplot", async() => {
+        const dom = createTestDom();
+        await renderBarplot(dom);
+
+        hoverBarplotItem(dom);
+        const content = tooltip(dom).innerHTML;
+        expect(tooltip(dom).style.visibility).toEqual("visible");
+
+        await renderTreemap(dom);
+
+        // The tooltip left behind is the barplot's, so the treemap cannot recognize it as its own.
+        expect(tooltip(dom).innerHTML).toEqual(content);
+        expect(tooltip(dom).style.visibility).toEqual("hidden");
+    });
+
+    it("should hide a stranded tooltip even when the incoming visualization has tooltips disabled", async() => {
+        const dom = createTestDom();
+        await renderBarplot(dom);
+
+        hoverBarplotItem(dom);
+        expect(tooltip(dom).style.visibility).toEqual("visible");
+
+        const settings = treemapSettings();
+        settings.enableTooltips = false;
+        await renderTreemap(dom, settings);
+
+        expect(tooltip(dom).style.visibility).toEqual("hidden");
+    });
+});

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -5,7 +5,7 @@ import {Bar, BarItem} from "./Bar";
 import BarplotPreprocessor from "./BarplotPreprocessor";
 import Tooltip from "../../utilities/Tooltip";
 import StyleUtilities from "../../utilities/StyleUtilities";
-import HostElement from "../../utilities/HostElement";
+import HostUtilities from "../../utilities/HostUtilities";
 
 /**
  * Height (in pixels) of the x-axis: its tick marks, their labels and the title underneath them.
@@ -143,7 +143,7 @@ export default class Barplot {
     }
 
     private renderBarplot(): void {
-        HostElement.clear(this.element, this.settings.tooltipContainer);
+        HostUtilities.clear(this.element, this.settings.tooltipContainer);
 
         const visElement = d3.select(this.element)
             .append("svg")

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -22,6 +22,11 @@ const AXIS_PADDING_TOP = 5;
  */
 const LEGEND_TITLE_PADDING_BOTTOM = 10;
 
+/**
+ * One item of one bar: what the rectangles the barplot is built from are bound to.
+ */
+type StackedSegment = { barIndex: number, title: string, shape: d3.SeriesPoint<Bar> };
+
 export default class Barplot {
     private readonly settings: BarplotSettings;
     private readonly data: Bar[];
@@ -61,12 +66,6 @@ export default class Barplot {
      * @param newWidth New total width (in pixels) of the visualization.
      */
     public resize(newWidth: number) {
-        // The render throws away the node the pointer is over, and a node that is removed never gets a mouseout of
-        // its own, so without this the tooltip is left on screen describing a bar that is no longer there.
-        if (this.settings.enableTooltips && this.tooltip) {
-            this.tooltip.hide();
-        }
-
         this.settings.width = newWidth;
 
         this.renderBarplot();
@@ -302,7 +301,6 @@ export default class Barplot {
         }
 
         // Instead of keeping track of n values per entry, we want to keep track of n bars with the entries
-        type StackedSegment = { barIndex: number, title: string, shape: d3.SeriesPoint<Bar> };
         const transposedStackedData: StackedSegment[][] =
             Array.from({ length: this.data.length }, () => []);
 
@@ -470,15 +468,15 @@ export default class Barplot {
         if (this.settings.highlightOnHover) {
             const barplot = d3.select(this.element);
 
-            // Select all barplot-items and make them slightly transparent
-            barplot.selectAll(".barplot-item").classed("barplot-item-highlighted", true);
-            // Except for the current element, we want this one to stand out of the rest
-            barplot.selectAll(`g[data-bar-item="${d.label}"]`).classed("barplot-item-highlighted", false);
+            // Everything is dimmed except the hovered category, which is what makes it stand out, and its entry in
+            // the legend. The category is matched on the datum d3 bound rather than through an attribute selector
+            // holding the label: labels are free text, and a taxon name carrying a quote or a bracket builds a
+            // selector that does not parse, which would throw out of this handler and leave the whole plot dimmed.
+            barplot.selectAll<SVGGElement, StackedSegment>(".barplot-item")
+                .classed("barplot-item-highlighted", segment => segment.title !== d.label);
 
-            // Also select the legend entry with the same label and highlight the corresponding rectangle
-            barplot.selectAll(".legend-item").classed("legend-item-highlighted", true);
-
-            barplot.selectAll(`g[data-legend-entry="${d.label}"]`).classed("legend-item-highlighted", false);
+            barplot.selectAll<SVGGElement, string>(".legend-item")
+                .classed("legend-item-highlighted", label => label !== d.label);
         }
     }
 

--- a/src/visualizations/barplot/Barplot.ts
+++ b/src/visualizations/barplot/Barplot.ts
@@ -5,6 +5,7 @@ import {Bar, BarItem} from "./Bar";
 import BarplotPreprocessor from "./BarplotPreprocessor";
 import Tooltip from "../../utilities/Tooltip";
 import StyleUtilities from "../../utilities/StyleUtilities";
+import HostElement from "../../utilities/HostElement";
 
 /**
  * Height (in pixels) of the x-axis: its tick marks, their labels and the title underneath them.
@@ -143,9 +144,7 @@ export default class Barplot {
     }
 
     private renderBarplot(): void {
-        // Constructing a barplot on an element that already holds one has to replace it, not add a second one next to
-        // it.
-        this.element.innerHTML = "";
+        HostElement.clear(this.element, this.settings.tooltipContainer);
 
         const visElement = d3.select(this.element)
             .append("svg")
@@ -469,15 +468,17 @@ export default class Barplot {
         }
 
         if (this.settings.highlightOnHover) {
+            const barplot = d3.select(this.element);
+
             // Select all barplot-items and make them slightly transparent
-            d3.selectAll(".barplot-item").classed("barplot-item-highlighted", true);
+            barplot.selectAll(".barplot-item").classed("barplot-item-highlighted", true);
             // Except for the current element, we want this one to stand out of the rest
-            d3.selectAll(`g[data-bar-item="${d.label}"]`).classed("barplot-item-highlighted", false);
+            barplot.selectAll(`g[data-bar-item="${d.label}"]`).classed("barplot-item-highlighted", false);
 
             // Also select the legend entry with the same label and highlight the corresponding rectangle
-            d3.selectAll(".legend-item").classed("legend-item-highlighted", true);
+            barplot.selectAll(".legend-item").classed("legend-item-highlighted", true);
 
-            d3.selectAll(`g[data-legend-entry="${d.label}"]`).classed("legend-item-highlighted", false);
+            barplot.selectAll(`g[data-legend-entry="${d.label}"]`).classed("legend-item-highlighted", false);
         }
     }
 
@@ -497,11 +498,13 @@ export default class Barplot {
         }
 
         if (this.settings.highlightOnHover) {
+            const barplot = d3.select(this.element);
+
             // Stop highlighting of barplot items
-            d3.selectAll(".barplot-item").classed("barplot-item-highlighted", false);
+            barplot.selectAll(".barplot-item").classed("barplot-item-highlighted", false);
 
             // Stop highlighting of the legend items
-            d3.selectAll(".legend-item").classed("legend-item-highlighted", false);
+            barplot.selectAll(".legend-item").classed("legend-item-highlighted", false);
         }
     }
 }

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -226,6 +226,37 @@ describe("Barplot", () => {
         expect(second.getElementsByClassName("legend-item-highlighted")).toHaveLength(0);
     });
 
+    it("should highlight by label even when the label holds selector syntax", async() => {
+        // Taxon names carry strain designations, which routinely hold quotes and brackets.
+        const quoted = "He said \"hi\"";
+        const data: Bar[] = [{
+            label: "Sample 1",
+            items: [
+                { label: quoted, counts: 10 },
+                { label: "back\\slash", counts: 5 },
+                { label: "bracket]", counts: 3 }
+            ]
+        }];
+
+        const jsDom = createTestDom();
+        await createBarplot(jsDom, new BarplotSettings(), data);
+
+        const element = jsDom.window.document.getElementById("visualization")!;
+        const hovered = element.querySelector(`[data-bar-item]`)!;
+
+        hovered.dispatchEvent(new jsDom.window.MouseEvent("mouseover", { clientX: 10, clientY: 50 }));
+
+        // The hovered category is the one that stands out, so it is the only one left undimmed.
+        const dimmed = (selector: string) => Array.from(element.querySelectorAll(selector))
+            .filter(node => node.classList.contains("barplot-item-highlighted")
+                || node.classList.contains("legend-item-highlighted"))
+            .map(node => node.getAttribute("data-bar-item") ?? node.getAttribute("data-legend-entry"));
+
+        expect(dimmed("[data-bar-item]")).toEqual(["back\\slash", "bracket]"]);
+        expect(dimmed("[data-legend-entry]")).toEqual(["back\\slash", "bracket]"]);
+        expect(hovered.classList.contains("barplot-item-highlighted")).toBe(false);
+    });
+
     it("should keep the defaults of the nested settings that are not given", async() => {
         // A plain object literal is what a user of the library passes in, and it only mentions what it changes. The
         // cast is what that costs in TypeScript: the constructor asks for a complete BarplotSettings.

--- a/src/visualizations/barplot/__tests__/Barplot.spec.ts
+++ b/src/visualizations/barplot/__tests__/Barplot.spec.ts
@@ -196,6 +196,36 @@ describe("Barplot", () => {
         expect(element.className.split(/\s+/).filter((name: string) => name === "barplot")).toHaveLength(1);
     });
 
+    // The document of the test environment rather than a JSDOM of its own: a selection that is not scoped to one
+    // barplot reaches across the whole document, and a barplot in a document nothing else lives in cannot show that.
+    it("should highlight only the barplot the cursor is over", async() => {
+        document.body.innerHTML = "";
+
+        const hosts = ["first", "second"].map(id => {
+            const host = document.createElement("div");
+            host.id = id;
+            document.body.appendChild(host);
+            return host;
+        });
+
+        for (const host of hosts) {
+            const settings = new BarplotSettings();
+            settings.width = 800;
+            settings.height = 800;
+            new Barplot(host, bars(), settings);
+            await waitForCondition(() => host.getElementsByTagName("svg").length > 0, 2000, 500);
+        }
+
+        const [first, second] = hosts;
+        first.querySelector(".barplot-item")!.dispatchEvent(
+            new MouseEvent("mouseover", { clientX: 10, clientY: 10 })
+        );
+
+        expect(first.getElementsByClassName("barplot-item-highlighted").length).toBeGreaterThan(0);
+        expect(second.getElementsByClassName("barplot-item-highlighted")).toHaveLength(0);
+        expect(second.getElementsByClassName("legend-item-highlighted")).toHaveLength(0);
+    });
+
     it("should keep the defaults of the nested settings that are not given", async() => {
         // A plain object literal is what a user of the library passes in, and it only mentions what it changes. The
         // cast is what that costs in TypeScript: the constructor asks for a complete BarplotSettings.

--- a/src/visualizations/heatmap/Heatmap.ts
+++ b/src/visualizations/heatmap/Heatmap.ts
@@ -7,7 +7,7 @@ import {HeatmapFeature} from "./HeatmapFeature";
 import {HeatmapValue} from "./HeatmapValue";
 import Preprocessor from "./Preprocessor";
 import Tooltip from "./../../utilities/Tooltip";
-import HostElement from "./../../utilities/HostElement";
+import HostUtilities from "./../../utilities/HostUtilities";
 import {VisualizationPadding} from "./../../Settings";
 
 import CanvasRenderHelper from "./../../render/CanvasRenderHelper";
@@ -142,7 +142,7 @@ export default class Heatmap {
         this.textHeight = this.settings.initialTextHeight;
 
         // Add a canvas to the desired element and set it's required properties
-        HostElement.clear(this.element, this.settings.tooltipContainer);
+        HostUtilities.clear(this.element, this.settings.tooltipContainer);
 
         // @ts-expect-error
         this.visElement = d3.select(this.element)

--- a/src/visualizations/heatmap/Heatmap.ts
+++ b/src/visualizations/heatmap/Heatmap.ts
@@ -7,6 +7,7 @@ import {HeatmapFeature} from "./HeatmapFeature";
 import {HeatmapValue} from "./HeatmapValue";
 import Preprocessor from "./Preprocessor";
 import Tooltip from "./../../utilities/Tooltip";
+import HostElement from "./../../utilities/HostElement";
 import {VisualizationPadding} from "./../../Settings";
 
 import CanvasRenderHelper from "./../../render/CanvasRenderHelper";
@@ -141,7 +142,7 @@ export default class Heatmap {
         this.textHeight = this.settings.initialTextHeight;
 
         // Add a canvas to the desired element and set it's required properties
-        this.element.innerHTML = "";
+        HostElement.clear(this.element, this.settings.tooltipContainer);
 
         // @ts-expect-error
         this.visElement = d3.select(this.element)

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -6,7 +6,7 @@ import DataNode, { DataNodeLike } from "./../../DataNode";
 import Tooltip from "./../../utilities/Tooltip";
 import NodeUtils from "./../../utilities/NodeUtils";
 import StyleUtilities from "./../../utilities/StyleUtilities";
-import HostElement from "./../../utilities/HostElement";
+import HostUtilities from "./../../utilities/HostUtilities";
 import ColorUtils from "./../../color/ColorUtils";
 
 
@@ -100,7 +100,7 @@ export default class Sunburst {
         this.initCss();
 
         // Prepare element and create SVG container
-        HostElement.clear(this.element, this.settings.tooltipContainer);
+        HostUtilities.clear(this.element, this.settings.tooltipContainer);
         // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)
             .append("div")

--- a/src/visualizations/sunburst/Sunburst.ts
+++ b/src/visualizations/sunburst/Sunburst.ts
@@ -6,6 +6,7 @@ import DataNode, { DataNodeLike } from "./../../DataNode";
 import Tooltip from "./../../utilities/Tooltip";
 import NodeUtils from "./../../utilities/NodeUtils";
 import StyleUtilities from "./../../utilities/StyleUtilities";
+import HostElement from "./../../utilities/HostElement";
 import ColorUtils from "./../../color/ColorUtils";
 
 
@@ -99,7 +100,7 @@ export default class Sunburst {
         this.initCss();
 
         // Prepare element and create SVG container
-        this.element.innerHTML = "";
+        HostElement.clear(this.element, this.settings.tooltipContainer);
         // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)
             .append("div")

--- a/src/visualizations/treemap/Treemap.ts
+++ b/src/visualizations/treemap/Treemap.ts
@@ -3,6 +3,7 @@ import TreemapSettings from "./TreemapSettings";
 import DataNode, { DataNodeLike } from "./../../DataNode";
 import Tooltip from "./../../utilities/Tooltip";
 import StyleUtilities from "./../../utilities/StyleUtilities";
+import HostElement from "./../../utilities/HostElement";
 import ColorUtils from "./../../color/ColorUtils";
 import TreemapPreprocessor from "./TreemapPreprocessor";
 
@@ -70,9 +71,7 @@ export default class Treemap {
             // @ts-expect-error
             .interpolate(d3.interpolateLab);
 
-        // Constructing a treemap on an element that already holds one has to replace it, not add a second one next to
-        // it.
-        this.element.innerHTML = "";
+        HostElement.clear(this.element, this.settings.tooltipContainer);
 
         // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)

--- a/src/visualizations/treemap/Treemap.ts
+++ b/src/visualizations/treemap/Treemap.ts
@@ -3,7 +3,7 @@ import TreemapSettings from "./TreemapSettings";
 import DataNode, { DataNodeLike } from "./../../DataNode";
 import Tooltip from "./../../utilities/Tooltip";
 import StyleUtilities from "./../../utilities/StyleUtilities";
-import HostElement from "./../../utilities/HostElement";
+import HostUtilities from "./../../utilities/HostUtilities";
 import ColorUtils from "./../../color/ColorUtils";
 import TreemapPreprocessor from "./TreemapPreprocessor";
 
@@ -71,7 +71,7 @@ export default class Treemap {
             // @ts-expect-error
             .interpolate(d3.interpolateLab);
 
-        HostElement.clear(this.element, this.settings.tooltipContainer);
+        HostUtilities.clear(this.element, this.settings.tooltipContainer);
 
         // @ts-expect-error
         this.breadCrumbs = d3.select(this.element)

--- a/src/visualizations/treeview/Treeview.ts
+++ b/src/visualizations/treeview/Treeview.ts
@@ -6,6 +6,7 @@ import MaxCountHeap from "./heap/MaxCountHeap";
 import TreeviewPreprocessor from "./TreeviewPreprocessor";
 import Tooltip from "./../../utilities/Tooltip";
 import { DataNodeLike } from "./../../DataNode";
+import HostElement from "./../../utilities/HostElement";
 
 type HPN<T> = d3.HierarchyPointNode<T>;
 type HPL<T> = d3.HierarchyPointLink<T>;
@@ -72,7 +73,7 @@ export default class Treeview {
         this.data = this.treeLayout(rootNode).descendants();
         this.root = this.data[0];
 
-        this.element.innerHTML = "";
+        HostElement.clear(this.element, this.settings.tooltipContainer);
 
         this.svg = d3.select(this.element)
             .append("svg")

--- a/src/visualizations/treeview/Treeview.ts
+++ b/src/visualizations/treeview/Treeview.ts
@@ -6,7 +6,7 @@ import MaxCountHeap from "./heap/MaxCountHeap";
 import TreeviewPreprocessor from "./TreeviewPreprocessor";
 import Tooltip from "./../../utilities/Tooltip";
 import { DataNodeLike } from "./../../DataNode";
-import HostElement from "./../../utilities/HostElement";
+import HostUtilities from "./../../utilities/HostUtilities";
 
 type HPN<T> = d3.HierarchyPointNode<T>;
 type HPL<T> = d3.HierarchyPointLink<T>;
@@ -73,7 +73,7 @@ export default class Treeview {
         this.data = this.treeLayout(rootNode).descendants();
         this.root = this.data[0];
 
-        HostElement.clear(this.element, this.settings.tooltipContainer);
+        HostUtilities.clear(this.element, this.settings.tooltipContainer);
 
         this.svg = d3.select(this.element)
             .append("svg")


### PR DESCRIPTION
Three bugs in the hover path. The first two both come down to a `mouseout` that never fires. None of them has an issue filed, and all three predate this branch.

Rebased onto `b0bd48f`, so this now sits on top of #214, #215 and #216. The rebase was clean.

## Bug 1: a visible tooltip is stranded when a visualization clears its host element

Every visualization starts by emptying the element it renders in. That takes away the node the pointer is over, and a node that is removed never gets a `mouseout` of its own, so the handler that would hide the tooltip never runs. The tooltip stays on screen, with content describing something that no longer exists, until the pointer happens to enter and leave another node.

Reproduced in three shapes: a barplot over a barplot, a treemap over a treemap, and a treemap over a barplot. The third one is the interesting case, because the tooltip left behind is still the barplot's, sitting underneath the treemap that stranded it.

## Bug 2: hovering one barplot dims every barplot on the page

`Barplot.mouseIn` and `Barplot.mouseOut` used `d3.selectAll(".barplot-item")` and `d3.selectAll(".legend-item")`, which walk the whole document. With two barplots on one page, hovering either of them dimmed both. Together with the mechanism above, a barplot that is replaced while the pointer is inside it also leaves its sibling permanently dimmed, since the `mouseout` that would undo the highlight never arrives.

## Bug 3: a label holding selector syntax breaks the highlight

`mouseIn` built its selectors by interpolating a category label into an attribute selector. A label containing a double quote produces a selector that does not parse:

```
SyntaxError: Invalid selector g[data-bar-item="He said "hi""]
```

The exception escapes the `mouseover` handler. The line above it had already set `barplot-item-highlighted` on every item, so what the user sees is the entire barplot dimmed with nothing standing out, and it stays that way until the pointer leaves. This is not a hypothetical: taxon names carry strain designations in quotes, and brackets and backslashes turn up too.

## The fixes

**Clearing the host element and hiding the tooltip now happen together**, in `HostUtilities.clear`. All five visualizations call it instead of assigning `innerHTML` themselves, so the pairing cannot be forgotten in one of them, and there is a single place where the reason is written down.

The utility is called `HostUtilities`, not `HostElement`. #216 landed `src/visualizations/__tests__/HostElement.spec.ts`, which covers the element a visualization renders into, and a spec file in this repository is named after the file it tests, so the original name would have pointed at the wrong thing.

**Hiding is a static `Tooltip.hideFor(reference, container)`** rather than an instance method. An instance method would not be enough for two reasons. A tooltip is shared per container, so the visible tooltip may well belong to a sibling and the incoming visualization has no way to tell; hiding it regardless is worth it, because the worst case is a sibling tooltip that comes back on the next mouse move, which is strictly better than stale content that stays until something else happens to clear it. And a visualization constructed with `enableTooltips: false` holds no `Tooltip` at all while a stranded tooltip may still be visible in the same container, so there is no instance to call anything on. `hideFor` looks the container up in the same map `create` uses and does nothing when there is no entry, so a container that never showed a tooltip is left alone and no element is created just to hide it. Resolving the container is now shared between `create` and `hideFor` through a `findContainer` helper; `create` still throws on a selector that matches nothing, `hideFor` stays quiet.

**The barplot's hover selections are scoped** to `d3.select(this.element)`.

**The hovered category is matched on the datum d3 bound**, not through a selector built from its label. The elements already carry the label as bound data, so no parsing is involved and the label can hold anything at all. It also turns two passes over the items into one. `CSS.escape` would have been correct too, but it fixes the symptom rather than removing the string round trip, and it would leave a second escaping question every time someone adds a selector here. Escaping by hand was not considered seriously. Nothing is caught and swallowed. Matching on the datum needed the `StackedSegment` type, which was local to `renderBarplot`, hoisted to module scope.

`mouseOut` clears both classes unconditionally and never built a selector from a label, so it did not have the same shape. These two lines in `mouseIn` were the only ones in the file, and the only interpolated selectors anywhere in `src/`.

### #215's local fix, now removed

#215 landed a `resize()` that hid the tooltip itself before rerendering, for exactly the reason above. `HostUtilities.clear` now runs on every `renderBarplot`, `resize()` included, so those five lines were a second mechanism for the same thing and are gone. The body of `resize()` is the width assignment and the re-render.

The test #215 added for it, "should hide a tooltip that is showing when it is resized", still passes with the local fix removed. That is the evidence the removal is safe: the test now exercises this branch's mechanism instead of #215's, and it does not need changing to do so.

The identical-looking block in `mouseOut` is the legitimate hide on a real mouse-out and was left alone.

#215's content-derived height does not interact with any of this. `contentHeight` and the getters behind it read settings and data only, with no DOM measurement, so it makes no difference that `HostUtilities.clear` runs just before them.

## Manual testing

Built the library and served the repository, then drove Chrome with puppeteer.

All 13 example pages load with no console errors and no page errors. Tooltips still appear on hover on the barplot, both treemaps, the sunbursts, the heatmaps and the treeview (the treeview shows its tooltip after a one second delay, which the check waits out). Four pages could not be checked for tooltips because the automated hover did not land on a node: `sunburst-flare.html`, `treeview-flare.html`, `treeview-multi.html` and `heatmap-clusters.html`. Those four behave identically on an unmodified build, so it is the hover targeting in the check, not a regression.

Separately, in a real browser, where the tooltip is a popover in the top layer rather than the plain hidden div JSDOM gives it:

- a barplot, hovered, then a treemap constructed over it: tooltip visible before, hidden after
- the same with `enableTooltips: false` on the treemap: tooltip still hidden
- two barplots side by side: hovering the first dims only the first, the second keeps no highlighted bar or legend entry
- a barplot whose categories are `He said "hi"`, `back\slash` and `bracket]`: hovering the first dims the other two and leaves the hovered one standing out

All four fail on a build without these changes and pass with them.

<details>
<summary>What was verified</summary>

- `npm run lint`, `npm run typecheck` and `npm test` are green.
- 131 tests on `main`, 139 here. Eight new tests: four in `src/visualizations/__tests__/StaleTooltip.spec.ts`, two in `Barplot.spec.ts` and two in `Tooltip.spec.ts`.
- Each regression test was run against the unmodified source first. The four stale tooltip tests all failed with `expected 'visible' to deeply equal 'hidden'`. The scoping test failed with `expected <g …(2)>…(2)</g> …(2) to have a length of +0 but got 4`, the four items of the second barplot that the first one had dimmed. The selector syntax test failed with `expected [ 'He said "hi"', 'back\slash', …(1) ] to deeply equal [ 'back\slash', 'bracket]' ]`, which is the whole plot dimmed and nothing standing out, with `SyntaxError: Invalid selector g[data-bar-item="He said "hi""]` on the console. It asserts which categories end up dimmed rather than merely that nothing threw.
- The scoping test uses the document of the test environment rather than a JSDOM of its own. The other barplot tests build their visualization in a detached JSDOM, where `d3.selectAll(".barplot-item")` selects nothing at all, so the bug is invisible there.
- The scoping fix and the label fix were checked together, in the browser and in the suite: hovering one barplot still leaves a second one on the page untouched.
- No image snapshot changed. All existing snapshot tests pass and `test/snapshots/diffs` is empty after the run, so no comparison came close enough to the threshold to write a diff. No snapshot was regenerated.
- The tooltip element is still created lazily: `Tooltip.hideFor` on a container that never showed one adds nothing to the document, which `Tooltip.spec.ts` covers, including for a container selector that matches nothing.

</details>

## One thing left alone

The class names `barplot-item`, `legend-item` and their `-highlighted` variants are not namespaced per instance, and neither are the `data-bar-item` and `data-legend-entry` attributes. Scoping the selections to the host element makes that harmless for the highlight, but the CSS is another matter: `initCss` scopes its rules to `settings.className`, which defaults to `"barplot"` for every barplot, so two barplots on a page that give different values to the settings that end up in the CSS still write over each other's stylesheet. That predates this branch and is not touched here. The treemap and the sunburst share the same arrangement.
